### PR TITLE
Refactor utilities and remove debug logs

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
-    "eject": "react-scripts eject"
+    "eject": "react-scripts eject",
+    "lint": "react-scripts lint"
   },
   "eslintConfig": {
     "extends": [

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,8 +9,6 @@ function App() {
   const [showSetup, setShowSetup] = useState(true);
 
   const startNewGame = (players: Player[], course: Course) => {
-    console.log('startNewGame called with:', { players, course });
-    
     const newGame: Game = {
       id: Date.now().toString(),
       date: new Date().toISOString().split('T')[0],
@@ -19,13 +17,9 @@ function App() {
       currentHole: 1,
       totalHoles: 18
     };
-    
-    console.log('New game created:', newGame);
-    console.log('Setting game state...');
+
     setGame(newGame);
-    console.log('Setting showSetup to false...');
     setShowSetup(false);
-    console.log('Game state updated successfully');
   };
 
   const updateScore = (playerId: string, holeNumber: number, strokes: number, putts: number) => {

--- a/src/components/CourseEditor.tsx
+++ b/src/components/CourseEditor.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { Course, CourseHole } from '../types/golf';
-import { deleteCustomCourse } from '../data/courses';
+import { deleteCustomCourse } from '../services/courseService';
 
 interface CourseEditorProps {
   course: Course;

--- a/src/components/CourseSelector.tsx
+++ b/src/components/CourseSelector.tsx
@@ -1,6 +1,12 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { Course } from '../types/golf';
-import { getCourseSuggestions, findCourseByName, defaultCustomCourse, loadCustomCourses, deleteCustomCourse } from '../data/courses';
+import {
+  getCourseSuggestions,
+  findCourseByName,
+  defaultCustomCourse,
+  loadCustomCourses,
+  deleteCustomCourse
+} from '../services/courseService';
 
 interface CourseSelectorProps {
   onCourseSelect: (course: Course) => void;

--- a/src/components/PlayerSetup.tsx
+++ b/src/components/PlayerSetup.tsx
@@ -1,6 +1,10 @@
 import React, { useState } from 'react';
 import { Player, PlayerSetup as PlayerSetupType, Course } from '../types/golf';
-import { saveCustomCourse, generateCourseId, defaultCustomCourse } from '../data/courses';
+import {
+  saveCustomCourse,
+  generateCourseId,
+  defaultCustomCourse
+} from '../services/courseService';
 import CourseSelector from './CourseSelector';
 import CourseEditor from './CourseEditor';
 
@@ -58,7 +62,6 @@ const PlayerSetup: React.FC<PlayerSetupProps> = ({ onStartGame }) => {
     // Save to localStorage
     try {
       saveCustomCourse(courseToSave);
-      console.log('Custom course saved to localStorage:', courseToSave);
     } catch (error) {
       console.error('Failed to save custom course:', error);
       alert('Failed to save course. Please try again.');
@@ -91,9 +94,7 @@ const PlayerSetup: React.FC<PlayerSetupProps> = ({ onStartGame }) => {
   };
 
   const handleStartGame = () => {
-    console.log('Start game clicked');
-    console.log('Valid players:', players.slice(0, activePlayers).filter(player => player.name.trim() !== ''));
-    console.log('Selected course:', selectedCourse);
+
     
     const validPlayers = players
       .slice(0, activePlayers)
@@ -109,7 +110,6 @@ const PlayerSetup: React.FC<PlayerSetupProps> = ({ onStartGame }) => {
       return;
     }
 
-    console.log('Creating game players...');
     // Convert PlayerSetup to Player with course data
     const gamePlayers: Player[] = validPlayers.map(player => ({
       ...player,
@@ -125,10 +125,7 @@ const PlayerSetup: React.FC<PlayerSetupProps> = ({ onStartGame }) => {
       }))
     }));
 
-    console.log('Game players created:', gamePlayers);
-    console.log('Calling onStartGame...');
     onStartGame(gamePlayers, selectedCourse);
-    console.log('onStartGame called successfully');
   };
 
   if (showCourseEditor && courseToEdit) {

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,0 +1,4 @@
+export { default as CourseEditor } from './CourseEditor';
+export { default as CourseSelector } from './CourseSelector';
+export { default as PlayerSetup } from './PlayerSetup';
+export { default as ScoreCard } from './ScoreCard';

--- a/src/data/courses.ts
+++ b/src/data/courses.ts
@@ -1,6 +1,5 @@
 import { Course } from '../types/golf';
 
-// Built-in courses that come with the app
 const builtInCourses: Course[] = [
   {
     id: 'pebble-beach',
@@ -67,7 +66,7 @@ const builtInCourses: Course[] = [
       { holeNumber: 2, par: 4, handicap: 5, distance: 453, description: 'Dyke' },
       { holeNumber: 3, par: 4, handicap: 15, distance: 397, description: 'Cartgate (Out)' },
       { holeNumber: 4, par: 4, handicap: 7, distance: 480, description: 'Ginger Beer' },
-      { holeNumber: 5, par: 5, handicap: 13, distance: 568, description: 'Hole O\'Cross (Out)' },
+      { holeNumber: 5, par: 5, handicap: 13, distance: 568, description: "Hole O'Cross (Out)" },
       { holeNumber: 6, par: 4, handicap: 3, distance: 412, description: 'Heathery (Out)' },
       { holeNumber: 7, par: 4, handicap: 9, distance: 371, description: 'High (Out)' },
       { holeNumber: 8, par: 3, handicap: 17, distance: 175, description: 'Short' },
@@ -75,7 +74,7 @@ const builtInCourses: Course[] = [
       { holeNumber: 10, par: 4, handicap: 8, distance: 386, description: 'Bobby Jones' },
       { holeNumber: 11, par: 3, handicap: 16, distance: 174, description: 'High (In)' },
       { holeNumber: 12, par: 4, handicap: 4, distance: 348, description: 'Heathery (In)' },
-      { holeNumber: 13, par: 4, handicap: 12, distance: 465, description: 'Hole O\'Cross (In)' },
+      { holeNumber: 13, par: 4, handicap: 12, distance: 465, description: "Hole O'Cross (In)" },
       { holeNumber: 14, par: 5, handicap: 6, distance: 618, description: 'Long' },
       { holeNumber: 15, par: 4, handicap: 2, distance: 455, description: 'Cartgate (In)' },
       { holeNumber: 16, par: 4, handicap: 10, distance: 423, description: 'Corner of the Dyke' },
@@ -85,7 +84,6 @@ const builtInCourses: Course[] = [
   }
 ];
 
-// Default custom course template
 const defaultCustomCourse: Course = {
   id: 'custom-course',
   name: 'Custom Course',
@@ -100,114 +98,4 @@ const defaultCustomCourse: Course = {
   }))
 };
 
-// LocalStorage key for custom courses
-const CUSTOM_COURSES_KEY = 'golfer-custom-courses';
-
-// Load custom courses from localStorage
-export const loadCustomCourses = (): Course[] => {
-  try {
-    const stored = localStorage.getItem(CUSTOM_COURSES_KEY);
-    if (stored) {
-      const parsed = JSON.parse(stored);
-      // Validate that it's an array of courses
-      if (Array.isArray(parsed)) {
-        return parsed.filter(course => 
-          course && 
-          typeof course.id === 'string' && 
-          typeof course.name === 'string' &&
-          Array.isArray(course.holes) &&
-          course.holes.length === 18
-        );
-      }
-    }
-  } catch (error) {
-    console.error('Error loading custom courses from localStorage:', error);
-  }
-  return [];
-};
-
-// Save custom courses to localStorage
-export const saveCustomCourses = (customCourses: Course[]): void => {
-  try {
-    localStorage.setItem(CUSTOM_COURSES_KEY, JSON.stringify(customCourses));
-  } catch (error) {
-    console.error('Error saving custom courses to localStorage:', error);
-  }
-};
-
-// Save a single custom course
-export const saveCustomCourse = (course: Course): void => {
-  const customCourses = loadCustomCourses();
-  const existingIndex = customCourses.findIndex(c => c.id === course.id);
-  
-  if (existingIndex >= 0) {
-    // Update existing course
-    customCourses[existingIndex] = course;
-  } else {
-    // Add new course
-    customCourses.push(course);
-  }
-  
-  saveCustomCourses(customCourses);
-};
-
-// Delete a custom course
-export const deleteCustomCourse = (courseId: string): void => {
-  const customCourses = loadCustomCourses();
-  const filtered = customCourses.filter(c => c.id !== courseId);
-  saveCustomCourses(filtered);
-};
-
-// Generate unique ID for new custom courses
-export const generateCourseId = (name: string): string => {
-  const baseId = name.toLowerCase()
-    .replace(/[^a-z0-9\s]/g, '')
-    .replace(/\s+/g, '-')
-    .substring(0, 30);
-  
-  const timestamp = Date.now().toString(36);
-  return `${baseId}-${timestamp}`;
-};
-
-// Get all courses (built-in + custom)
-export const getAllCourses = (): Course[] => {
-  const customCourses = loadCustomCourses();
-  return [...builtInCourses, ...customCourses];
-};
-
-// Maintain backward compatibility
-export const courses = getAllCourses();
-
-export const findCourseByName = (name: string): Course | undefined => {
-  const allCourses = getAllCourses();
-  const searchName = name.toLowerCase().trim();
-  return allCourses.find(course => 
-    course.name.toLowerCase().includes(searchName) ||
-    course.location?.toLowerCase().includes(searchName)
-  );
-};
-
-export const getCourseSuggestions = (input: string): Course[] => {
-  const allCourses = getAllCourses();
-  
-  if (!input.trim()) {
-    // Return built-in courses first, then recent custom courses
-    const customCourses = loadCustomCourses().slice(-2); // Last 2 custom courses
-    return [...builtInCourses.slice(0, 3), ...customCourses].slice(0, 5);
-  }
-  
-  const searchTerm = input.toLowerCase().trim();
-  const filtered = allCourses.filter(course => 
-    course.name.toLowerCase().includes(searchTerm) ||
-    course.location?.toLowerCase().includes(searchTerm)
-  );
-  
-  // Always include "Custom Course" option if searching
-  if (!filtered.some(c => c.id === 'custom-course')) {
-    filtered.push(defaultCustomCourse);
-  }
-  
-  return filtered.slice(0, 5);
-};
-
-export { defaultCustomCourse }; 
+export { builtInCourses as default, defaultCustomCourse };

--- a/src/services/courseService.ts
+++ b/src/services/courseService.ts
@@ -1,0 +1,102 @@
+import { Course } from '../types/golf';
+import builtInCourses, { defaultCustomCourse } from '../data/courses';
+
+const CUSTOM_COURSES_KEY = 'golfer-custom-courses';
+
+export const loadCustomCourses = (): Course[] => {
+  try {
+    const stored = localStorage.getItem(CUSTOM_COURSES_KEY);
+    if (stored) {
+      const parsed = JSON.parse(stored);
+      if (Array.isArray(parsed)) {
+        return parsed.filter(course =>
+          course &&
+          typeof course.id === 'string' &&
+          typeof course.name === 'string' &&
+          Array.isArray(course.holes) &&
+          course.holes.length === 18
+        );
+      }
+    }
+  } catch (error) {
+    console.error('Error loading custom courses:', error);
+  }
+  return [];
+};
+
+export const saveCustomCourses = (customCourses: Course[]): void => {
+  try {
+    localStorage.setItem(CUSTOM_COURSES_KEY, JSON.stringify(customCourses));
+  } catch (error) {
+    console.error('Error saving custom courses:', error);
+  }
+};
+
+export const saveCustomCourse = (course: Course): void => {
+  const customCourses = loadCustomCourses();
+  const existingIndex = customCourses.findIndex(c => c.id === course.id);
+
+  if (existingIndex >= 0) {
+    customCourses[existingIndex] = course;
+  } else {
+    customCourses.push(course);
+  }
+
+  saveCustomCourses(customCourses);
+};
+
+export const deleteCustomCourse = (courseId: string): void => {
+  const customCourses = loadCustomCourses();
+  const filtered = customCourses.filter(c => c.id !== courseId);
+  saveCustomCourses(filtered);
+};
+
+export const generateCourseId = (name: string): string => {
+  const baseId = name
+    .toLowerCase()
+    .replace(/[^a-z0-9\s]/g, '')
+    .replace(/\s+/g, '-')
+    .substring(0, 30);
+
+  const timestamp = Date.now().toString(36);
+  return `${baseId}-${timestamp}`;
+};
+
+export const getAllCourses = (): Course[] => {
+  const customCourses = loadCustomCourses();
+  return [...builtInCourses, ...customCourses];
+};
+
+export const courses = getAllCourses();
+
+export const findCourseByName = (name: string): Course | undefined => {
+  const allCourses = getAllCourses();
+  const searchName = name.toLowerCase().trim();
+  return allCourses.find(course =>
+    course.name.toLowerCase().includes(searchName) ||
+    course.location?.toLowerCase().includes(searchName)
+  );
+};
+
+export const getCourseSuggestions = (input: string): Course[] => {
+  const allCourses = getAllCourses();
+
+  if (!input.trim()) {
+    const customCourses = loadCustomCourses().slice(-2);
+    return [...builtInCourses.slice(0, 3), ...customCourses].slice(0, 5);
+  }
+
+  const searchTerm = input.toLowerCase().trim();
+  const filtered = allCourses.filter(course =>
+    course.name.toLowerCase().includes(searchTerm) ||
+    course.location?.toLowerCase().includes(searchTerm)
+  );
+
+  if (!filtered.some(c => c.id === 'custom-course')) {
+    filtered.push(defaultCustomCourse);
+  }
+
+  return filtered.slice(0, 5);
+};
+
+export { defaultCustomCourse };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,6 +13,7 @@
     "strict": true,
     "forceConsistentCasingInFileNames": true,
     "noFallthroughCasesInSwitch": true,
+    "noUnusedLocals": true,
     "module": "esnext",
     "moduleResolution": "node",
     "resolveJsonModule": true,


### PR DESCRIPTION
## Summary
- move course helpers to a new `services/courseService` module
- simplify `courses.ts` to just store built-in data
- add component barrel file for cleaner imports
- remove console debug statements
- add lint script and stricter TypeScript option

## Testing
- `npm run lint` *(fails: react-scripts not found)*
- `npx tsc -p tsconfig.json --noEmit` *(fails: missing type definitions)*

------
https://chatgpt.com/codex/tasks/task_e_685a9ebe1cb88325859143e36aeae1ea