### PR TITLE
Improve mobile scorecard and update app title

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -24,7 +24,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>React App</title>
+    <title>The Tour</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,6 +1,6 @@
 {
-  "short_name": "React App",
-  "name": "Create React App Sample",
+  "short_name": "The Tour",
+  "name": "The Tour",
   "icons": [
     {
       "src": "favicon.ico",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -60,7 +60,7 @@ function App() {
     <div className="min-h-screen bg-gradient-to-br from-green-400 to-blue-500">
       <div className="container mx-auto px-4 py-8">
         <header className="text-center mb-8">
-          <h1 className="text-4xl font-bold text-white mb-2">🏌️ Golf Score Tracker</h1>
+          <h1 className="text-4xl font-bold text-white mb-2">🏌️ The Tour</h1>
           <p className="text-white/80">Track your game with style</p>
         </header>
 

--- a/src/components/ScoreCard.tsx
+++ b/src/components/ScoreCard.tsx
@@ -1,23 +1,36 @@
-import { useState, Fragment } from 'react';
-import type { ChangeEvent } from 'react';
-import { Game, Player, HoleScore } from '../types/golf';
+import { useState, Fragment } from "react";
+import type { ChangeEvent } from "react";
+import { Game, Player, HoleScore } from "../types/golf";
 
 interface ScoreCardProps {
   game: Game;
-  onUpdateScore: (playerId: string, holeNumber: number, strokes: number, putts: number) => void;
+  onUpdateScore: (
+    playerId: string,
+    holeNumber: number,
+    strokes: number,
+    putts: number,
+  ) => void;
 }
 
 const ScoreCard = ({ game, onUpdateScore }: ScoreCardProps) => {
-  const [editingCell, setEditingCell] = useState<{ playerId: string; holeNumber: number; type: 'strokes' | 'putts' } | null>(null);
-  const [editingValue, setEditingValue] = useState<string>('');
+  const [editingCell, setEditingCell] = useState<{
+    playerId: string;
+    holeNumber: number;
+    type: "strokes" | "putts";
+  } | null>(null);
+  const [editingValue, setEditingValue] = useState<string>("");
 
-  const handleCellClick = (playerId: string, holeNumber: number, type: 'strokes' | 'putts') => {
-    const player = game.players.find(p => p.id === playerId);
+  const handleCellClick = (
+    playerId: string,
+    holeNumber: number,
+    type: "strokes" | "putts",
+  ) => {
+    const player = game.players.find((p) => p.id === playerId);
     if (player) {
-      const hole = player.holes.find(h => h.holeNumber === holeNumber);
+      const hole = player.holes.find((h) => h.holeNumber === holeNumber);
       if (hole) {
-        const currentValue = type === 'strokes' ? hole.strokes : hole.putts;
-        setEditingValue(currentValue > 0 ? currentValue.toString() : '');
+        const currentValue = type === "strokes" ? hole.strokes : hole.putts;
+        setEditingValue(currentValue > 0 ? currentValue.toString() : "");
       }
     }
     setEditingCell({ playerId, holeNumber, type });
@@ -25,56 +38,62 @@ const ScoreCard = ({ game, onUpdateScore }: ScoreCardProps) => {
 
   const handleCellChange = (value: string) => {
     if (!editingCell) return;
-    
+
     const numValue = parseInt(value) || 0;
     const { playerId, holeNumber, type } = editingCell;
-    const player = game.players.find(p => p.id === playerId);
-    
+    const player = game.players.find((p) => p.id === playerId);
+
     if (player) {
-      const hole = player.holes.find(h => h.holeNumber === holeNumber);
+      const hole = player.holes.find((h) => h.holeNumber === holeNumber);
       if (hole) {
-        const newStrokes = type === 'strokes' ? numValue : hole.strokes;
-        const newPutts = type === 'putts' ? numValue : hole.putts;
+        const newStrokes = type === "strokes" ? numValue : hole.strokes;
+        const newPutts = type === "putts" ? numValue : hole.putts;
         onUpdateScore(playerId, holeNumber, newStrokes, newPutts);
       }
     }
-    
+
     setEditingCell(null);
-    setEditingValue('');
+    setEditingValue("");
   };
 
   const handleInputChange = (e: ChangeEvent<HTMLInputElement>) => {
     setEditingValue(e.target.value);
   };
 
-  const isEditing = (playerId: string, holeNumber: number, type: 'strokes' | 'putts') => {
-    return editingCell?.playerId === playerId && 
-           editingCell?.holeNumber === holeNumber && 
-           editingCell?.type === type;
+  const isEditing = (
+    playerId: string,
+    holeNumber: number,
+    type: "strokes" | "putts",
+  ) => {
+    return (
+      editingCell?.playerId === playerId &&
+      editingCell?.holeNumber === holeNumber &&
+      editingCell?.type === type
+    );
   };
 
   const getScoreColor = (strokes: number, par: number) => {
-    if (strokes === 0) return '';
-    if (strokes < par) return 'bg-green-100 text-green-800';
-    if (strokes === par) return 'bg-blue-100 text-blue-800';
-    if (strokes === par + 1) return 'bg-yellow-100 text-yellow-800';
-    return 'bg-red-100 text-red-800';
+    if (strokes === 0) return "";
+    if (strokes < par) return "bg-green-100 text-green-800";
+    if (strokes === par) return "bg-blue-100 text-blue-800";
+    if (strokes === par + 1) return "bg-yellow-100 text-yellow-800";
+    return "bg-red-100 text-red-800";
   };
 
   const getScoreBorderStyle = (strokes: number, par: number) => {
-    if (strokes === 0) return '';
-    if (strokes === par - 2) return 'border-2 border-green-600 rounded-full'; // Double circle for eagle
-    if (strokes < par) return 'border-2 border-green-600 rounded-full'; // Circle for birdie
-    if (strokes === par) return ''; // No special border for par
-    if (strokes === par + 1) return 'border-2 border-yellow-600'; // Square for bogey
-    if (strokes === par + 2) return 'border-2 border-red-600'; // Double square for double bogey
-    return 'border-2 border-red-800 relative'; // Cross-hatched for triple bogey+
+    if (strokes === 0) return "";
+    if (strokes === par - 2) return "border-2 border-green-600 rounded-full"; // Double circle for eagle
+    if (strokes < par) return "border-2 border-green-600 rounded-full"; // Circle for birdie
+    if (strokes === par) return ""; // No special border for par
+    if (strokes === par + 1) return "border-2 border-yellow-600"; // Square for bogey
+    if (strokes === par + 2) return "border-2 border-red-600"; // Double square for double bogey
+    return "border-2 border-red-800 relative"; // Cross-hatched for triple bogey+
   };
 
   const getDoubleCircleStyle = (strokes: number, par: number) => {
     if (strokes === par - 2) {
       return {
-        boxShadow: 'inset 0 0 0 2px white, inset 0 0 0 4px green'
+        boxShadow: "inset 0 0 0 2px white, inset 0 0 0 4px green",
       };
     }
     return {};
@@ -83,7 +102,7 @@ const ScoreCard = ({ game, onUpdateScore }: ScoreCardProps) => {
   const getDoubleSquareStyle = (strokes: number, par: number) => {
     if (strokes === par + 2) {
       return {
-        boxShadow: 'inset 0 0 0 2px white, inset 0 0 0 4px red'
+        boxShadow: "inset 0 0 0 2px white, inset 0 0 0 4px red",
       };
     }
     return {};
@@ -94,14 +113,14 @@ const ScoreCard = ({ game, onUpdateScore }: ScoreCardProps) => {
       return {
         background: `linear-gradient(45deg, rgba(255,255,255,0.8) 40%, rgba(139,0,0,0.6) 40%, rgba(139,0,0,0.6) 60%, rgba(255,255,255,0.8) 60%), 
                      linear-gradient(-45deg, rgba(255,255,255,0.8) 40%, rgba(139,0,0,0.6) 40%, rgba(139,0,0,0.6) 60%, rgba(255,255,255,0.8) 60%)`,
-        backgroundSize: '6px 6px'
+        backgroundSize: "6px 6px",
       };
     }
     return {};
   };
 
   const getScoreDisplay = (strokes: number, par: number) => {
-    if (strokes === 0) return '-';
+    if (strokes === 0) return "-";
     return `${strokes}`;
   };
 
@@ -116,13 +135,15 @@ const ScoreCard = ({ game, onUpdateScore }: ScoreCardProps) => {
 
   const calculateAdjustedScore = (player: Player) => {
     if (player.handicap === 0) return player.totalScore;
-    
+
     // Sort holes by handicap (lowest to highest) - easiest holes first
-    const sortedHoles = [...player.holes].sort((a, b) => a.holeHandicap - b.holeHandicap);
-    
+    const sortedHoles = [...player.holes].sort(
+      (a, b) => a.holeHandicap - b.holeHandicap,
+    );
+
     let adjustedScore = player.totalScore;
     let strokesToDeduct = 0;
-    
+
     // Apply strokes starting from easiest holes (lowest handicap numbers)
     // For handicap > 18, we cycle through holes multiple times
     for (let i = 0; i < player.handicap; i++) {
@@ -132,23 +153,25 @@ const ScoreCard = ({ game, onUpdateScore }: ScoreCardProps) => {
         strokesToDeduct++;
       }
     }
-    
+
     return adjustedScore - strokesToDeduct;
   };
 
   const getAdjustedScoreForHole = (player: Player, holeNumber: number) => {
     if (player.handicap === 0) return null;
-    
-    const hole = player.holes.find(h => h.holeNumber === holeNumber);
+
+    const hole = player.holes.find((h) => h.holeNumber === holeNumber);
     if (!hole || hole.strokes === 0) return null;
-    
+
     // Calculate how many strokes this player gets on this hole
-    const sortedHoles = [...player.holes].sort((a, b) => a.holeHandicap - b.holeHandicap);
-    const holeIndex = sortedHoles.findIndex(h => h.holeNumber === holeNumber);
-    
+    const sortedHoles = [...player.holes].sort(
+      (a, b) => a.holeHandicap - b.holeHandicap,
+    );
+    const holeIndex = sortedHoles.findIndex((h) => h.holeNumber === holeNumber);
+
     // Calculate strokes to deduct for this specific hole
     let strokesToDeduct = 0;
-    
+
     // For each stroke in the handicap, check if this hole gets it
     for (let i = 0; i < player.handicap; i++) {
       const cycleIndex = i % 18; // Which hole in the current cycle
@@ -156,7 +179,7 @@ const ScoreCard = ({ game, onUpdateScore }: ScoreCardProps) => {
         strokesToDeduct++;
       }
     }
-    
+
     // Return adjusted score if strokes are deducted, otherwise return original score
     return strokesToDeduct > 0 ? hole.strokes - strokesToDeduct : hole.strokes;
   };
@@ -167,32 +190,48 @@ const ScoreCard = ({ game, onUpdateScore }: ScoreCardProps) => {
   };
 
   return (
-    <div className="golf-card overflow-x-auto">
+    <div className="golf-card">
       <h3 className="text-xl font-bold text-gray-800 mb-4">Score Card</h3>
-      
-      <div className="min-w-full">
-        <table className="w-full border-collapse">
+
+      {/* Desktop Table */}
+      <div className="hidden md:block overflow-x-auto">
+        <table className="min-w-full border-collapse">
           <thead>
             <tr className="bg-gray-100">
-              <th className="border border-gray-300 px-3 py-2 text-left font-semibold">Player</th>
-              <th className="border border-gray-300 px-3 py-2 text-center font-semibold">Handicap</th>
+              <th className="border border-gray-300 px-3 py-2 text-left font-semibold">
+                Player
+              </th>
+              <th className="border border-gray-300 px-3 py-2 text-center font-semibold">
+                Handicap
+              </th>
               {game.course.holes.map((hole) => (
-                <th key={hole.holeNumber} className="border border-gray-300 px-2 py-2 text-center font-semibold text-sm">
+                <th
+                  key={hole.holeNumber}
+                  className="border border-gray-300 px-2 py-2 text-center font-semibold text-sm"
+                >
                   <div>{hole.holeNumber}</div>
                   <div className="text-xs text-gray-600">Par {hole.par}</div>
                   <div className="text-xs text-gray-500">H{hole.handicap}</div>
                 </th>
               ))}
-              <th className="border border-gray-300 px-3 py-2 text-center font-semibold">Total</th>
-              <th className="border border-gray-300 px-3 py-2 text-center font-semibold">To Par</th>
-              <th className="border border-gray-300 px-3 py-2 text-center font-semibold">Putts</th>
+              <th className="border border-gray-300 px-3 py-2 text-center font-semibold">
+                Total
+              </th>
+              <th className="border border-gray-300 px-3 py-2 text-center font-semibold">
+                To Par
+              </th>
+              <th className="border border-gray-300 px-3 py-2 text-center font-semibold">
+                Putts
+              </th>
             </tr>
           </thead>
           <tbody>
             {game.players.map((player, playerIndex) => (
               <Fragment key={player.id}>
                 {/* Strokes Row */}
-                <tr className={playerIndex % 2 === 0 ? 'bg-white' : 'bg-gray-50'}>
+                <tr
+                  className={playerIndex % 2 === 0 ? "bg-white" : "bg-gray-50"}
+                >
                   <td className="border border-gray-300 px-3 py-2 font-medium">
                     {player.name}
                   </td>
@@ -201,17 +240,29 @@ const ScoreCard = ({ game, onUpdateScore }: ScoreCardProps) => {
                   </td>
                   {player.holes.map((hole) => {
                     const value = hole.strokes;
-                    const editing = isEditing(player.id, hole.holeNumber, 'strokes');
-                    
+                    const editing = isEditing(
+                      player.id,
+                      hole.holeNumber,
+                      "strokes",
+                    );
+
                     return (
-                      <td key={hole.holeNumber} className="border border-gray-300 px-2 py-1 text-center">
+                      <td
+                        key={hole.holeNumber}
+                        className="border border-gray-300 px-2 py-1 text-center"
+                      >
                         {editing ? (
                           <input
                             type="number"
                             value={editingValue}
                             onChange={handleInputChange}
                             onBlur={(e) => handleCellChange(e.target.value)}
-                            onKeyPress={(e) => e.key === 'Enter' && handleCellChange((e.target as HTMLInputElement).value)}
+                            onKeyPress={(e) =>
+                              e.key === "Enter" &&
+                              handleCellChange(
+                                (e.target as HTMLInputElement).value,
+                              )
+                            }
                             className="w-12 text-center border border-gray-300 rounded px-1"
                             autoFocus
                             min="1"
@@ -219,14 +270,21 @@ const ScoreCard = ({ game, onUpdateScore }: ScoreCardProps) => {
                           />
                         ) : (
                           <button
-                            onClick={() => handleCellClick(player.id, hole.holeNumber, 'strokes')}
-                            className={`w-full py-1 hover:bg-gray-200 transition-colors text-sm ${
-                              getScoreColor(value, hole.par)
-                            } ${getScoreBorderStyle(value, hole.par)}`}
+                            onClick={() =>
+                              handleCellClick(
+                                player.id,
+                                hole.holeNumber,
+                                "strokes",
+                              )
+                            }
+                            className={`mx-auto w-8 h-8 flex items-center justify-center hover:bg-gray-200 transition-colors text-sm ${getScoreColor(
+                              value,
+                              hole.par,
+                            )} ${getScoreBorderStyle(value, hole.par)}`}
                             style={{
                               ...getCrossHatchStyle(value, hole.par),
                               ...getDoubleCircleStyle(value, hole.par),
-                              ...getDoubleSquareStyle(value, hole.par)
+                              ...getDoubleSquareStyle(value, hole.par),
                             }}
                           >
                             {getScoreDisplay(value, hole.par)}
@@ -241,7 +299,7 @@ const ScoreCard = ({ game, onUpdateScore }: ScoreCardProps) => {
                   <td className="border border-gray-300 px-3 py-2 text-center font-bold bg-purple-100">
                     {(() => {
                       const toPar = calculateTotalToPar(player);
-                      if (toPar === 0) return 'E';
+                      if (toPar === 0) return "E";
                       return toPar > 0 ? `+${toPar}` : `${toPar}`;
                     })()}
                   </td>
@@ -252,7 +310,11 @@ const ScoreCard = ({ game, onUpdateScore }: ScoreCardProps) => {
 
                 {/* Adjusted Score Row (only show if player has handicap) */}
                 {player.handicap > 0 && (
-                  <tr className={playerIndex % 2 === 0 ? 'bg-white' : 'bg-gray-50'}>
+                  <tr
+                    className={
+                      playerIndex % 2 === 0 ? "bg-white" : "bg-gray-50"
+                    }
+                  >
                     <td className="border border-gray-300 px-3 py-1 text-xs text-gray-500">
                       Adjusted
                     </td>
@@ -260,14 +322,24 @@ const ScoreCard = ({ game, onUpdateScore }: ScoreCardProps) => {
                       ({player.handicap})
                     </td>
                     {player.holes.map((hole) => {
-                      const adjustedScore = getAdjustedScoreForHole(player, hole.holeNumber);
-                      
+                      const adjustedScore = getAdjustedScoreForHole(
+                        player,
+                        hole.holeNumber,
+                      );
+
                       return (
-                        <td key={hole.holeNumber} className="border border-gray-300 px-2 py-1 text-center">
+                        <td
+                          key={hole.holeNumber}
+                          className="border border-gray-300 px-2 py-1 text-center"
+                        >
                           {adjustedScore !== null ? (
-                            <div className={`text-xs font-medium ${
-                              adjustedScore < hole.strokes ? 'text-blue-600' : 'text-gray-600'
-                            }`}>
+                            <div
+                              className={`text-xs font-medium ${
+                                adjustedScore < hole.strokes
+                                  ? "text-blue-600"
+                                  : "text-gray-600"
+                              }`}
+                            >
                               {adjustedScore}
                             </div>
                           ) : (
@@ -282,33 +354,49 @@ const ScoreCard = ({ game, onUpdateScore }: ScoreCardProps) => {
                     <td className="border border-gray-300 px-3 py-1 text-center font-bold bg-purple-50 text-purple-700 text-sm">
                       {(() => {
                         const adjustedToPar = calculateAdjustedToPar(player);
-                        if (adjustedToPar === 0) return 'E';
-                        return adjustedToPar > 0 ? `+${adjustedToPar}` : `${adjustedToPar}`;
+                        if (adjustedToPar === 0) return "E";
+                        return adjustedToPar > 0
+                          ? `+${adjustedToPar}`
+                          : `${adjustedToPar}`;
                       })()}
                     </td>
                     <td className="border border-gray-300 px-3 py-1"></td>
                   </tr>
                 )}
-                
+
                 {/* Putts Row */}
-                <tr className={playerIndex % 2 === 0 ? 'bg-white' : 'bg-gray-50'}>
+                <tr
+                  className={playerIndex % 2 === 0 ? "bg-white" : "bg-gray-50"}
+                >
                   <td className="border border-gray-300 px-3 py-1 text-xs text-gray-500">
                     Putts
                   </td>
                   <td className="border border-gray-300 px-3 py-1"></td>
                   {player.holes.map((hole) => {
                     const value = hole.putts;
-                    const editing = isEditing(player.id, hole.holeNumber, 'putts');
-                    
+                    const editing = isEditing(
+                      player.id,
+                      hole.holeNumber,
+                      "putts",
+                    );
+
                     return (
-                      <td key={hole.holeNumber} className="border border-gray-300 px-2 py-1 text-center">
+                      <td
+                        key={hole.holeNumber}
+                        className="border border-gray-300 px-2 py-1 text-center"
+                      >
                         {editing ? (
                           <input
                             type="number"
                             value={editingValue}
                             onChange={handleInputChange}
                             onBlur={(e) => handleCellChange(e.target.value)}
-                            onKeyPress={(e) => e.key === 'Enter' && handleCellChange((e.target as HTMLInputElement).value)}
+                            onKeyPress={(e) =>
+                              e.key === "Enter" &&
+                              handleCellChange(
+                                (e.target as HTMLInputElement).value,
+                              )
+                            }
                             className="w-8 text-center border border-gray-300 rounded px-1 text-xs"
                             autoFocus
                             min="0"
@@ -316,12 +404,18 @@ const ScoreCard = ({ game, onUpdateScore }: ScoreCardProps) => {
                           />
                         ) : (
                           <button
-                            onClick={() => handleCellClick(player.id, hole.holeNumber, 'putts')}
+                            onClick={() =>
+                              handleCellClick(
+                                player.id,
+                                hole.holeNumber,
+                                "putts",
+                              )
+                            }
                             className={`w-full py-1 rounded hover:bg-gray-200 transition-colors text-xs ${
-                              value > 0 ? 'bg-green-100' : ''
+                              value > 0 ? "bg-green-100" : ""
                             }`}
                           >
-                            {value > 0 ? value : '-'}
+                            {value > 0 ? value : "-"}
                           </button>
                         )}
                       </td>
@@ -336,51 +430,249 @@ const ScoreCard = ({ game, onUpdateScore }: ScoreCardProps) => {
           </tbody>
         </table>
       </div>
-      
-      {/* Summary */}
-      <div className="mt-6 grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
-        {game.players.map(player => {
+
+      {/* Mobile Layout */}
+      <div className="md:hidden space-y-4">
+        {game.players.map((player) => {
           const toPar = calculateTotalToPar(player);
           const adjustedScore = calculateAdjustedScore(player);
           const adjustedToPar = calculateAdjustedToPar(player);
-          
+
+          return (
+            <div key={player.id} className="border rounded-lg overflow-hidden">
+              <div className="flex justify-between items-center bg-gray-100 px-3 py-2">
+                <span className="font-semibold">{player.name}</span>
+                <span className="text-sm">HCP {player.handicap}</span>
+              </div>
+              <table className="w-full border-collapse">
+                <thead className="text-xs">
+                  <tr className="bg-gray-50">
+                    <th className="border px-2 py-1 text-left">Hole</th>
+                    <th className="border px-2 py-1 text-center">Strokes</th>
+                    <th className="border px-2 py-1 text-center">Adj</th>
+                    <th className="border px-2 py-1 text-center">Putts</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {player.holes.map((hole) => {
+                    const strokeEditing = isEditing(
+                      player.id,
+                      hole.holeNumber,
+                      "strokes",
+                    );
+                    const puttEditing = isEditing(
+                      player.id,
+                      hole.holeNumber,
+                      "putts",
+                    );
+                    return (
+                      <tr key={hole.holeNumber}>
+                        <td className="border px-2 py-1">
+                          <div className="font-medium">{hole.holeNumber}</div>
+                          <div className="text-xs text-gray-600">
+                            Par {hole.par}
+                          </div>
+                        </td>
+                        <td className="border px-2 py-1 text-center">
+                          {strokeEditing ? (
+                            <input
+                              type="number"
+                              value={editingValue}
+                              onChange={handleInputChange}
+                              onBlur={(e) => handleCellChange(e.target.value)}
+                              onKeyPress={(e) =>
+                                e.key === "Enter" &&
+                                handleCellChange(
+                                  (e.target as HTMLInputElement).value,
+                                )
+                              }
+                              className="w-12 text-center border border-gray-300 rounded px-1 text-sm"
+                              autoFocus
+                              min="1"
+                              max="20"
+                            />
+                          ) : (
+                            <button
+                              onClick={() =>
+                                handleCellClick(
+                                  player.id,
+                                  hole.holeNumber,
+                                  "strokes",
+                                )
+                              }
+                              className={`mx-auto w-8 h-8 flex items-center justify-center hover:bg-gray-200 transition-colors text-sm ${getScoreColor(hole.strokes, hole.par)} ${getScoreBorderStyle(hole.strokes, hole.par)}`}
+                              style={{
+                                ...getCrossHatchStyle(hole.strokes, hole.par),
+                                ...getDoubleCircleStyle(hole.strokes, hole.par),
+                                ...getDoubleSquareStyle(hole.strokes, hole.par),
+                              }}
+                            >
+                              {getScoreDisplay(hole.strokes, hole.par)}
+                            </button>
+                          )}
+                        </td>
+                        <td className="border px-2 py-1 text-center text-sm">
+                          {(() => {
+                            const adj = getAdjustedScoreForHole(
+                              player,
+                              hole.holeNumber,
+                            );
+                            return adj !== null ? adj : "-";
+                          })()}
+                        </td>
+                        <td className="border px-2 py-1 text-center">
+                          {puttEditing ? (
+                            <input
+                              type="number"
+                              value={editingValue}
+                              onChange={handleInputChange}
+                              onBlur={(e) => handleCellChange(e.target.value)}
+                              onKeyPress={(e) =>
+                                e.key === "Enter" &&
+                                handleCellChange(
+                                  (e.target as HTMLInputElement).value,
+                                )
+                              }
+                              className="w-8 text-center border border-gray-300 rounded px-1 text-xs"
+                              autoFocus
+                              min="0"
+                              max="10"
+                            />
+                          ) : (
+                            <button
+                              onClick={() =>
+                                handleCellClick(
+                                  player.id,
+                                  hole.holeNumber,
+                                  "putts",
+                                )
+                              }
+                              className={`w-full py-1 rounded hover:bg-gray-200 transition-colors text-xs ${hole.putts > 0 ? "bg-green-100" : ""}`}
+                            >
+                              {hole.putts > 0 ? hole.putts : "-"}
+                            </button>
+                          )}
+                        </td>
+                      </tr>
+                    );
+                  })}
+                  <tr className="bg-gray-50 font-semibold text-sm">
+                    <td className="border px-2 py-1">Total</td>
+                    <td className="border px-2 py-1 text-center">
+                      {player.totalScore}
+                    </td>
+                    <td className="border px-2 py-1 text-center">
+                      {player.handicap > 0 ? adjustedScore : "-"}
+                    </td>
+                    <td className="border px-2 py-1 text-center">
+                      {player.totalPutts}
+                    </td>
+                  </tr>
+                  <tr className="bg-gray-50 font-semibold text-sm">
+                    <td className="border px-2 py-1">To Par</td>
+                    <td className="border px-2 py-1 text-center" colSpan={3}>
+                      {toPar === 0 ? "E" : toPar > 0 ? `+${toPar}` : `${toPar}`}
+                    </td>
+                  </tr>
+                  {player.handicap > 0 && (
+                    <>
+                      <tr className="bg-gray-50 font-semibold text-sm">
+                        <td className="border px-2 py-1">Adjusted Score</td>
+                        <td
+                          className="border px-2 py-1 text-center"
+                          colSpan={3}
+                        >
+                          {adjustedScore}
+                        </td>
+                      </tr>
+                      <tr className="bg-gray-50 font-semibold text-sm">
+                        <td className="border px-2 py-1">Adjusted To Par</td>
+                        <td
+                          className="border px-2 py-1 text-center"
+                          colSpan={3}
+                        >
+                          {adjustedToPar === 0
+                            ? "E"
+                            : adjustedToPar > 0
+                              ? `+${adjustedToPar}`
+                              : `${adjustedToPar}`}
+                        </td>
+                      </tr>
+                    </>
+                  )}
+                </tbody>
+              </table>
+            </div>
+          );
+        })}
+      </div>
+
+      {/* Summary */}
+      <div className="mt-6 grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
+        {game.players.map((player) => {
+          const toPar = calculateTotalToPar(player);
+          const adjustedScore = calculateAdjustedScore(player);
+          const adjustedToPar = calculateAdjustedToPar(player);
+
           return (
             <div key={player.id} className="bg-gray-50 rounded-lg p-4">
-              <h4 className="font-semibold text-gray-800 mb-2">{player.name}</h4>
+              <h4 className="font-semibold text-gray-800 mb-2">
+                {player.name}
+              </h4>
               <div className="space-y-1 text-sm">
                 <div className="flex justify-between">
                   <span>Total Score:</span>
-                  <span className="font-bold text-blue-600">{player.totalScore}</span>
+                  <span className="font-bold text-blue-600">
+                    {player.totalScore}
+                  </span>
                 </div>
                 <div className="flex justify-between">
                   <span>To Par:</span>
-                  <span className={`font-bold ${
-                    toPar === 0 ? 'text-gray-600' : 
-                    toPar > 0 ? 'text-red-600' : 'text-green-600'
-                  }`}>
-                    {toPar === 0 ? 'E' : toPar > 0 ? `+${toPar}` : `${toPar}`}
+                  <span
+                    className={`font-bold ${
+                      toPar === 0
+                        ? "text-gray-600"
+                        : toPar > 0
+                          ? "text-red-600"
+                          : "text-green-600"
+                    }`}
+                  >
+                    {toPar === 0 ? "E" : toPar > 0 ? `+${toPar}` : `${toPar}`}
                   </span>
                 </div>
                 {player.handicap > 0 && (
                   <>
                     <div className="flex justify-between">
                       <span>Adjusted Score:</span>
-                      <span className="font-bold text-blue-600">{adjustedScore}</span>
+                      <span className="font-bold text-blue-600">
+                        {adjustedScore}
+                      </span>
                     </div>
                     <div className="flex justify-between">
                       <span>Adjusted To Par:</span>
-                      <span className={`font-bold ${
-                        adjustedToPar === 0 ? 'text-gray-600' : 
-                        adjustedToPar > 0 ? 'text-red-600' : 'text-green-600'
-                      }`}>
-                        {adjustedToPar === 0 ? 'E' : adjustedToPar > 0 ? `+${adjustedToPar}` : `${adjustedToPar}`}
+                      <span
+                        className={`font-bold ${
+                          adjustedToPar === 0
+                            ? "text-gray-600"
+                            : adjustedToPar > 0
+                              ? "text-red-600"
+                              : "text-green-600"
+                        }`}
+                      >
+                        {adjustedToPar === 0
+                          ? "E"
+                          : adjustedToPar > 0
+                            ? `+${adjustedToPar}`
+                            : `${adjustedToPar}`}
                       </span>
                     </div>
                   </>
                 )}
                 <div className="flex justify-between">
                   <span>Total Putts:</span>
-                  <span className="font-bold text-green-600">{player.totalPutts}</span>
+                  <span className="font-bold text-green-600">
+                    {player.totalPutts}
+                  </span>
                 </div>
                 <div className="flex justify-between">
                   <span>Handicap:</span>
@@ -395,4 +687,4 @@ const ScoreCard = ({ game, onUpdateScore }: ScoreCardProps) => {
   );
 };
 
-export default ScoreCard; 
+export default ScoreCard;


### PR DESCRIPTION
## Summary
- rename app to **The Tour** in UI and metadata
- add a dedicated mobile layout for the scorecard for easier entry on small screens
- show handicap-adjusted scores in the mobile table
- keep birdie/bogey indicators perfectly square or circular

## Testing
- `npm test --silent` *(fails: react-scripts not found)*
- `npm run lint` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685aa4c382fc8325842430945513a506