### PR TITLE
Fix grid layout for hole editor

### DIFF
--- a/src/components/CourseEditor.tsx
+++ b/src/components/CourseEditor.tsx
@@ -247,7 +247,7 @@ const CourseEditor = ({ course, onSaveCourse, onCancel, onDeleteCourse }: Course
         {/* Hole Editor - Compact Grid */}
         <div>
           <h3 className="text-sm font-semibold text-gray-800 mb-3">Hole Details</h3>
-          <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-6 gap-2">
+          <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-9 gap-2">
             {editedCourse.holes.map((hole) => (
               <div key={hole.holeNumber} className="bg-white border border-gray-200 rounded-lg p-2 hover:shadow-sm transition-shadow">
                 <div className="text-center">

--- a/src/components/ScoreCard.tsx
+++ b/src/components/ScoreCard.tsx
@@ -471,7 +471,7 @@ const ScoreCard = ({ game, onUpdateScore }: ScoreCardProps) => {
                           <div className="font-medium">{hole.holeNumber}</div>
                           <div className="text-xs text-gray-600 flex items-center space-x-1">
                             <span>Par {hole.par}</span>
-                            <span className="text-gray-500">H{hole.handicap}</span>
+                            <span className="text-gray-500">H{hole.holeHandicap}</span>
                           </div>
                         </td>
                         <td className="border px-2 py-1 text-center">


### PR DESCRIPTION
## Summary
- adjust course editor layout to use two rows of nine holes
- fix mobile scorecard to display hole handicaps instead of player handicaps

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ab23632508325ba5b9ad9ae2dc5f4