### PR TITLE
Add remote course search

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ A modern, responsive golf score tracking application built with React and TypeSc
   - Pebble Beach Golf Links (CA)
   - Augusta National Golf Club (GA)
   - St Andrews Old Course (Scotland)
+- **Public Course Database**: Search hundreds of courses online by typing a
+  course name into the selector
 - **Custom Course Builder**: Create and edit your own courses
 - **Course Details**: Par, handicap, distance, and hole descriptions
 - **Local Storage**: Save custom courses for future games
@@ -104,6 +106,9 @@ The app includes three world-famous golf courses:
 - **Pebble Beach Golf Links**: Iconic oceanside course
 - **Augusta National**: Home of The Masters
 - **St Andrews Old Course**: The birthplace of golf
+- **Search Public Database**: Quickly find new courses online.
+  Simply start typing a course name in the selector and matching courses from
+  the public database will appear.
 
 #### Creating Custom Courses
 1. Select "Create Custom Course" during setup

--- a/src/components/CourseSelector.tsx
+++ b/src/components/CourseSelector.tsx
@@ -2,7 +2,8 @@ import { useState, useEffect, useRef } from 'react';
 import type { ChangeEvent, KeyboardEvent } from 'react';
 import { Course } from '../types/golf';
 import {
-  getCourseSuggestions,
+  getCourseSuggestionsAsync,
+  fetchPublicCourses,
   findCourseByName,
   defaultCustomCourse,
   loadCustomCourses,
@@ -30,16 +31,32 @@ const CourseSelector = ({ onCourseSelect, selectedCourse, refreshKey }: CourseSe
     setSavedCourses(customCourses);
   }, [refreshKey]);
 
+  // Preload public courses on mount
   useEffect(() => {
-    if (inputValue.trim()) {
-      const newSuggestions = getCourseSuggestions(inputValue);
-      setSuggestions(newSuggestions);
-      setShowSuggestions(true);
-    } else {
-      const defaultSuggestions = getCourseSuggestions('');
-      setSuggestions(defaultSuggestions);
-      setShowSuggestions(false);
-    }
+    fetchPublicCourses().catch(() => undefined);
+  }, []);
+
+  useEffect(() => {
+    let active = true;
+    const load = async () => {
+      if (inputValue.trim()) {
+        const newSuggestions = await getCourseSuggestionsAsync(inputValue);
+        if (active) {
+          setSuggestions(newSuggestions);
+          setShowSuggestions(true);
+        }
+      } else {
+        const defaultSuggestions = await getCourseSuggestionsAsync('');
+        if (active) {
+          setSuggestions(defaultSuggestions);
+          setShowSuggestions(false);
+        }
+      }
+    };
+    load();
+    return () => {
+      active = false;
+    };
   }, [inputValue, refreshKey]);
 
   const handleInputChange = (e: ChangeEvent<HTMLInputElement>) => {
@@ -65,9 +82,10 @@ const CourseSelector = ({ onCourseSelect, selectedCourse, refreshKey }: CourseSe
       setShowSuggestions(true);
     } else {
       // Show default suggestions when focused
-      const defaultSuggestions = getCourseSuggestions('');
-      setSuggestions(defaultSuggestions);
-      setShowSuggestions(true);
+      getCourseSuggestionsAsync('').then((defaultSuggestions) => {
+        setSuggestions(defaultSuggestions);
+        setShowSuggestions(true);
+      });
     }
   };
 
@@ -121,10 +139,10 @@ const CourseSelector = ({ onCourseSelect, selectedCourse, refreshKey }: CourseSe
           onBlur={handleInputBlur}
           onFocus={handleInputFocus}
           onKeyDown={handleKeyDown}
-          placeholder="Search for a course or enter custom course name..."
+          placeholder="Search courses online or enter custom course name..."
           className="golf-input w-full pr-10"
         />
-        
+
         {inputValue && (
           <button
             onClick={() => setInputValue('')}
@@ -134,6 +152,9 @@ const CourseSelector = ({ onCourseSelect, selectedCourse, refreshKey }: CourseSe
           </button>
         )}
       </div>
+      <p className="text-xs text-gray-500 mt-1">
+        Start typing to search the public course database.
+      </p>
 
       {/* Course Suggestions */}
       {showSuggestions && (


### PR DESCRIPTION
## Summary
- load public courses from an online API and cache them in localStorage
- expose async helpers in courseService
- update CourseSelector to fetch suggestions asynchronously
- preload public courses on component mount
- document the new online course database
- clarify that typing in the course selector searches the public course database

## Testing
- `npm test --silent` *(fails: react-scripts not found)*
- `npm run lint --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ab671c7648325903fb85f940a3b52