### PR TITLE
Handle errors when fetching public course data

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ A modern, responsive golf score tracking application built with React and TypeSc
 - **Pre-loaded Famous Courses**:
   - Pebble Beach Golf Links (CA)
   - Augusta National Golf Club (GA)
-  - St Andrews Old Course (Scotland)
+ - St Andrews Old Course (Scotland)
 - **Public Course Database**: Search hundreds of courses online by typing a
   course name into the selector. Matching results appear automatically as you
   type.
@@ -110,6 +110,14 @@ The app includes three world-famous golf courses:
 - **Search Public Database**: Quickly find new courses online. Start typing a
   course name in the selector and matching courses from the public database
   will appear immediately.
+
+### Public Course Database
+
+The course selector queries the public API at
+`https://golf-courses-api.vercel.app/courses` whenever you search for a course
+name. An active internet connection is required. If the request fails, you'll
+see a notice below the selector and only the built-in courses will be
+available.
 
 #### Creating Custom Courses
 1. Select "Create Custom Course" during setup

--- a/src/components/CourseSelector.tsx
+++ b/src/components/CourseSelector.tsx
@@ -7,7 +7,8 @@ import {
   findCourseByName,
   defaultCustomCourse,
   loadCustomCourses,
-  deleteCustomCourse
+  deleteCustomCourse,
+  getLastPublicCourseError
 } from '../services/courseService';
 
 interface CourseSelectorProps {
@@ -23,6 +24,7 @@ const CourseSelector = ({ onCourseSelect, selectedCourse, refreshKey }: CourseSe
   const [isCustomCourse, setIsCustomCourse] = useState(false);
   const [showSavedCourses, setShowSavedCourses] = useState(false);
   const [savedCourses, setSavedCourses] = useState<Course[]>([]);
+  const [publicError, setPublicError] = useState<string | null>(null);
   const inputRef = useRef<HTMLInputElement>(null);
 
   // Load saved custom courses
@@ -44,12 +46,14 @@ const CourseSelector = ({ onCourseSelect, selectedCourse, refreshKey }: CourseSe
         if (active) {
           setSuggestions(newSuggestions);
           setShowSuggestions(true);
+          setPublicError(getLastPublicCourseError());
         }
       } else {
         const defaultSuggestions = await getCourseSuggestionsAsync('');
         if (active) {
           setSuggestions(defaultSuggestions);
           setShowSuggestions(false);
+          setPublicError(getLastPublicCourseError());
         }
       }
     };
@@ -155,6 +159,11 @@ const CourseSelector = ({ onCourseSelect, selectedCourse, refreshKey }: CourseSe
       <p className="text-xs text-gray-500 mt-1">
         Start typing to search the public course database.
       </p>
+      {publicError && (
+        <p className="text-xs text-red-600 mt-1">
+          Could not fetch public courses. Results may be limited.
+        </p>
+      )}
 
       {/* Course Suggestions */}
       {showSuggestions && (

--- a/src/services/courseService.ts
+++ b/src/services/courseService.ts
@@ -105,6 +105,12 @@ export { defaultCustomCourse };
 
 const PUBLIC_COURSES_KEY = 'golfer-public-courses';
 let publicCoursesCache: Course[] | null = null;
+let lastPublicCourseError: string | null = null;
+
+export const getLastPublicCourseError = (): string | null => lastPublicCourseError;
+export const clearLastPublicCourseError = (): void => {
+  lastPublicCourseError = null;
+};
 
 export const fetchPublicCourses = async (): Promise<Course[]> => {
   if (publicCoursesCache) {
@@ -118,11 +124,13 @@ export const fetchPublicCourses = async (): Promise<Course[]> => {
       const parsed = JSON.parse(stored);
       if (Array.isArray(parsed)) {
         publicCoursesCache = parsed;
+        lastPublicCourseError = null;
         return parsed;
       }
     }
   } catch (err) {
     console.error('Failed to load cached public courses', err);
+    lastPublicCourseError = (err as Error).message;
   }
 
   try {
@@ -137,10 +145,12 @@ export const fetchPublicCourses = async (): Promise<Course[]> => {
     if (Array.isArray(courses)) {
       publicCoursesCache = courses as Course[];
       localStorage.setItem(PUBLIC_COURSES_KEY, JSON.stringify(publicCoursesCache));
+      lastPublicCourseError = null;
       return publicCoursesCache;
     }
   } catch (err) {
     console.error('Error fetching public courses:', err);
+    lastPublicCourseError = (err as Error).message;
   }
 
   return [];
@@ -176,10 +186,12 @@ export const searchPublicCourses = async (query: string): Promise<Course[]> => {
 
     if (Array.isArray(courses)) {
       searchCache[term] = courses as Course[];
+      lastPublicCourseError = null;
       return searchCache[term];
     }
   } catch (err) {
     console.error('Error searching public courses:', err);
+    lastPublicCourseError = (err as Error).message;
   }
 
   return [];


### PR DESCRIPTION
## Summary
- capture public-course API failures in courseService
- surface connection errors in the CourseSelector UI
- document the public course API in the README

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685abf4db7148325b4044c18c8f83937