### PR TITLE
Switch to GolfCourseAPI

### DIFF
--- a/GolfCourseAPI.yml
+++ b/GolfCourseAPI.yml
@@ -1,0 +1,328 @@
+openapi: 3.0.0
+info:
+  title: GolfCourseAPI
+  description: >
+    An API service that provides golf course data to clients, including
+    course name, location, tee box data, course rating and slope rating.
+  version: 1.0.0
+servers:
+  - url: https://api.golfcourseapi.com/
+paths:
+  /v1/search:
+    get:
+      summary: Search for a golf course
+      description: >
+        This endpoint allows clients to search for a golf course based on 
+        either the course name or the club name. (The service will return 
+        the most relevant matches first.)
+      security:
+        - ApiKeyAuth: []
+      operationId: getCoursesBySearch
+      parameters:
+        - in: query
+          name: search_query
+          required: true
+          description: The search term used to retrieve a given golf course or golf club.
+          schema:
+            type: string
+            example: pinehurst
+      responses:
+        '200':
+          description: Successful get request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CourseSearch'
+        '401':
+          $ref:  '#/components/responses/UnauthorizedError'
+  /v1/courses/{id}:
+    get:
+      summary: Get golf course
+      description: >
+        This resource represents an individual golf course in the system.
+        Each golf course is identified by a numeric `id`.
+      security:
+        - ApiKeyAuth: []
+      operationId: getCourseById
+      parameters:
+        - name: id
+          in: path
+          description: Golf Course ID
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '200':
+          description: Successful get request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Course'
+        '401':
+          $ref:  '#/components/responses/UnauthorizedError'
+  /v1/users:
+    post:
+      summary: Register a new user
+      requestBody:
+        description: >
+          Register a new user with an email address. Also done via the 
+          web form at https://www.golfcourseapi.com/sign-in.
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RegisterForm'
+      responses:
+        '201':
+          description: Created a new user
+  /v1/users/activated:
+    put:
+      summary: Activate a new user account
+      requestBody:
+        description: >
+          Activate a new user with a token provided to the user's email after registration. 
+          Also done via the process started by https://www.golfcourseapi.com/sign-in.
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ActivatePayload'
+      responses:
+        '200':
+          description: Activated user
+  /v1/healthcheck:
+    get:
+      summary: Healthcheck
+      description: >
+        This endpoint returns the current status of the API service, 
+        including whether the API is available and the environment
+        and version hash of the current version.
+      responses:
+        '200':
+          description: Healthcheck returned successfully
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Healthcheck"  
+components:
+  securitySchemes:
+    ApiKeyAuth:
+      type: apiKey
+      in: header       
+      name: "Authorization: Key <your API key>"
+  schemas:
+    Healthcheck:
+      type: object
+      properties:
+        status:
+          type: string
+        system_info:
+          type: object
+          properties:
+            environment: 
+              type: string
+            version: 
+              type: string
+      example:
+        status: available
+        system_info: 
+          type: object
+          properties:
+            environment: production
+            version: e91c89471337e4f938928da49c072d0cad0ec176
+    Course:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+          example: 99
+        club_name:
+          type: string
+          example: Murray Golf Club
+        course_name: 
+          type: string
+          example: Course No. 1
+        location: 
+          type: object
+          properties:
+            address:
+              type: string
+              example: 124 Golf Course Lane, Murray, KY 42071, USA
+            city:
+              type: string
+              example: Murray
+            state:
+              type: string
+              example: KY
+            country:
+              type: string
+              example: United States
+            latitude:
+              type: number
+              format: float
+              example: 39.621742
+            longitude:
+              type: number
+              format: float
+              example: -80.34734
+        tees:
+          type: object
+          properties:
+            female:
+              type: array
+              items:
+                $ref: '#/components/schemas/TeeBox'
+            male:
+              type: array
+              items:
+                $ref: '#/components/schemas/TeeBox'
+    CourseSearch:
+      type: object
+      properties:
+        courses:
+          type: array
+          items:
+            $ref: '#/components/schemas/Course'
+          example:
+            - id: 34
+              club_name: Lubbock Country Club
+              course_name: Lubbock Country Club
+              location:
+                address: 124 Golf Course Lane, Murray, KY 42071, USA
+    TeeBox:
+      type: object
+      properties:
+        tee_name:
+          type: string
+          example: Blue
+        course_rating:
+          type: number
+          format: float
+          example: 75.7
+        slope_rating:
+          type: integer
+          example: 132
+        bogey_rating: 
+          type: number
+          format: float
+          example: 106.7
+        total_yards: 
+          type: integer
+          example: 6348
+        total_meters: 
+          type: integer
+          example: 5805
+        number_of_holes: 
+          type: integer
+          example: 18
+        par_total: 
+          type: integer
+          example: 73
+        front_course_rating: 
+          type: number
+          format: float
+          example: 37.6
+        front_slope_rating: 
+          type: integer
+          example: 134
+        front_bogey_rating: 
+          type: number
+          format: float
+          example: 53.4
+        back_course_rating: 
+          type: number
+          format: float
+          example: 38.1
+        back_slope_rating: 
+          type: integer
+          example: 129
+        back_bogey_rating: 
+          type: number
+          format: float
+          example: 53.3
+        holes: 
+          $ref: '#/components/schemas/ArrayOfHoles'
+    ArrayOfHoles:
+      type: array
+      items:
+        type: object
+        properties: 
+          par:
+            type: integer
+          yardage:
+            type: integer
+          handicap:
+            type: integer
+      example: 
+        - par: 4
+          yardage: 484
+          handicap: 9
+        - par: 3
+          yardage: 189
+          handicap: 17
+        - par: 5
+          yardage: 587
+          handicap: 2
+        - par: 4
+          yardage: 484
+          handicap: 9
+        - par: 3
+          yardage: 189
+          handicap: 17
+        - par: 5
+          yardage: 587
+          handicap: 2
+        - par: 4
+          yardage: 484
+          handicap: 9
+        - par: 3
+          yardage: 189
+          handicap: 17
+        - par: 5
+          yardage: 587
+          handicap: 2
+    RegisterForm:
+      type: object
+      properties:
+        email:
+          type: string
+      example:
+        email: joesmith@gmail.com
+    ActivatePayload:
+      type: object
+      properties:
+        email:
+          type: string
+      example:
+        token: LPGYZYT4KMBX3GMDRFK74ZXIT4
+    Metadata:
+      type: object
+      properties:
+        current_page:
+          type: integer
+        page_size:
+          type: integer
+        first_page:
+          type: integer
+        last_page:
+          type: integer
+        total_records:
+          type: integer
+  responses:
+    UnauthorizedError:
+      description: API key is missing or invalid
+      headers:
+        WWW-Authenticate:
+          schema:
+            type: string
+            example: Key
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              error:
+                type: string
+                example: API key is missing or invalid

--- a/README.md
+++ b/README.md
@@ -113,11 +113,10 @@ The app includes three world-famous golf courses:
 
 ### Public Course Database
 
-The course selector queries the public API at
-`https://golf-courses-api.vercel.app/courses` whenever you search for a course
-name. An active internet connection is required. If the request fails, you'll
-see a notice below the selector and only the built-in courses will be
-available.
+The course selector now uses **GolfCourseAPI** at
+`https://api.golfcourseapi.com/v1/search` to find remote courses. Set your API
+key in the `REACT_APP_GOLFCOURSE_API_KEY` environment variable before starting
+the app. If the request fails, only the built-in courses will be available.
 
 #### Creating Custom Courses
 1. Select "Create Custom Course" during setup


### PR DESCRIPTION
## Summary
- document GolfCourseAPI usage in README
- add GolfCourseAPI OpenAPI spec
- map remote course objects and update fetch helpers

## Testing
- `npx tsc -p tsconfig.json --noEmit` *(fails: Cannot find module 'react')*

------
https://chatgpt.com/codex/tasks/task_e_685acb78a53c83258cd00bcde595e3d0