### PR TITLE
Add Closest to Pin skin support

### DIFF
--- a/src/types/golf.ts
+++ b/src/types/golf.ts
@@ -47,4 +47,5 @@ export interface Game {
   players: Player[];
   currentHole: number;
   totalHoles: number;
-} 
+  closestToPin: Record<number, string | null>;
+}


### PR DESCRIPTION
## Summary
- track closest-to-pin selections in `Game`
- award skins based on selected closest-to-pin winners
- allow updating closest-to-pin winners from ScoreCard
- render a "Closest to Pin" row for relevant par-3 holes

## Testing
- `npm test --silent` *(fails: react-scripts not found)*
- `npm run build` *(fails: react-scripts not found)*
- `npx tsc --noEmit` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_685cb462cde883259f1f7b96edc3daeb