### PR TITLE
Add Closest to Pin skin support

### DIFF
--- a/src/components/ScoreCard.tsx
+++ b/src/components/ScoreCard.tsx
@@ -10,9 +10,10 @@ interface ScoreCardProps {
     strokes: number,
     putts: number,
   ) => void;
+  onUpdateClosest: (holeNumber: number, playerId: string | null) => void;
 }
 
-const ScoreCard = ({ game, onUpdateScore }: ScoreCardProps) => {
+const ScoreCard = ({ game, onUpdateScore, onUpdateClosest }: ScoreCardProps) => {
   const [editingCell, setEditingCell] = useState<{
     playerId: string;
     holeNumber: number;
@@ -55,6 +56,31 @@ const ScoreCard = ({ game, onUpdateScore }: ScoreCardProps) => {
   const handleInputChange = (e: ChangeEvent<HTMLInputElement>) => {
     setEditingValue(e.target.value);
   };
+
+  const getClosestHoleForSide = (side: "front" | "back"): number | null => {
+    const [start, end] = side === "front" ? [1, 9] : [10, 18];
+    const par3Holes = game.course.holes
+      .filter(
+        (h) => h.holeNumber >= start && h.holeNumber <= end && h.par === 3,
+      )
+      .map((h) => h.holeNumber)
+      .sort((a, b) => a - b);
+
+    for (const hole of par3Holes) {
+      const val = game.closestToPin[hole];
+      if (val === undefined) return hole; // first eligible par-3 not set yet
+      if (val === null) continue; // allow next par-3 if no winner
+      // once a winner exists, no further holes are eligible
+      return null;
+    }
+
+    return null;
+  };
+
+  const frontClosestHole = getClosestHoleForSide("front");
+  const backClosestHole = getClosestHoleForSide("back");
+  const isClosestHole = (holeNumber: number) =>
+    holeNumber === frontClosestHole || holeNumber === backClosestHole;
 
   const isEditing = (playerId: string, holeNumber: number) => {
     return (
@@ -354,6 +380,42 @@ const ScoreCard = ({ game, onUpdateScore }: ScoreCardProps) => {
 
               </Fragment>
             ))}
+            <tr className="bg-yellow-50">
+              <td className="border border-gray-300 px-3 py-2 font-medium">
+                Closest to Pin
+              </td>
+              <td className="border border-gray-300 px-3 py-2" />
+              {game.course.holes.map((hole) => (
+                <td
+                  key={hole.holeNumber}
+                  className="border border-gray-300 px-2 py-1 text-center"
+                >
+                  {isClosestHole(hole.holeNumber) ? (
+                    <select
+                      className="text-sm"
+                      value={game.closestToPin[hole.holeNumber] ?? ""}
+                      onChange={(e) =>
+                        onUpdateClosest(
+                          hole.holeNumber,
+                          e.target.value === "" ? null : e.target.value,
+                        )
+                      }
+                    >
+                      <option value="">None</option>
+                      {game.players.map((p) => (
+                        <option key={p.id} value={p.id}>
+                          {p.name}
+                        </option>
+                      ))}
+                    </select>
+                  ) : null}
+                </td>
+              ))}
+              <td
+                className="border border-gray-300 px-3 py-2"
+                colSpan={3}
+              ></td>
+            </tr>
           </tbody>
         </table>
       </div>

--- a/src/types/golf.ts
+++ b/src/types/golf.ts
@@ -47,4 +47,5 @@ export interface Game {
   players: Player[];
   currentHole: number;
   totalHoles: number;
-} 
+  closestToPin: Record<number, string | null>;
+}


### PR DESCRIPTION
## Summary
- track closest-to-pin selections in `Game`
- award skins based on selected closest-to-pin winners
- allow updating closest-to-pin winners from ScoreCard
- render a "Closest to Pin" row for relevant par-3 holes
- fix function ordering issue that caused a compile error
- ensure closest-hole detection stops after a winner is chosen
- fix leftover merge conflict text in `ScoreCard`

## Testing
- `npm test --silent` *(fails: react-scripts not found)*
- `npm run build` *(fails: react-scripts not found)*
- `npx tsc --noEmit` *(fails: missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_685cb462cde883259f1f7b96edc3daeb