### PR TITLE
Fix closest to pin dropdown persistence

### DIFF
--- a/src/components/ScoreCard.tsx
+++ b/src/components/ScoreCard.tsx
@@ -92,7 +92,9 @@ const ScoreCard = ({ game, onUpdateScore, onUpdateClosest }: ScoreCardProps) => 
     "back",
   );
   const isClosestHole = (holeNumber: number) =>
-    holeNumber === frontClosestHole || holeNumber === backClosestHole;
+    holeNumber === frontClosestHole ||
+    holeNumber === backClosestHole ||
+    game.closestToPin[holeNumber] !== undefined;
 
   const isEditing = (playerId: string, holeNumber: number) => {
     return (


### PR DESCRIPTION
## Summary
- keep closest-to-pin dropdowns visible after a winner is selected
- show previously selected par-3 holes in the dropdown logic

## Testing
- `npm test --silent` *(fails: react-scripts not found)*
- `npm run lint` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861cf4cb1508325bba5a58aff5a5594