### PR TITLE
Fix closest to pin dropdown persistence

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -121,7 +121,30 @@ function App() {
 
   const updateClosestToPin = (holeNumber: number, playerId: string | null) => {
     if (!game) return;
-    const closest = { ...game.closestToPin, [holeNumber]: playerId };
+    let closest: Record<number, string | null> = {
+      ...game.closestToPin,
+      [holeNumber]: playerId,
+    };
+
+    if (playerId) {
+      const sideStart = holeNumber <= 9 ? 1 : 10;
+      const sideEnd = holeNumber <= 9 ? 9 : 18;
+      const laterPar3 = game.course.holes
+        .filter(
+          (h) =>
+            h.par === 3 &&
+            h.holeNumber > holeNumber &&
+            h.holeNumber >= sideStart &&
+            h.holeNumber <= sideEnd,
+        )
+        .map((h) => h.holeNumber);
+
+      closest = { ...closest };
+      for (const h of laterPar3) {
+        delete closest[h];
+      }
+    }
+
     const playersWithSkins = calculateSkins(game.players, closest);
     setGame({ ...game, closestToPin: closest, players: playersWithSkins });
   };

--- a/src/components/ScoreCard.tsx
+++ b/src/components/ScoreCard.tsx
@@ -92,7 +92,9 @@ const ScoreCard = ({ game, onUpdateScore, onUpdateClosest }: ScoreCardProps) => 
     "back",
   );
   const isClosestHole = (holeNumber: number) =>
-    holeNumber === frontClosestHole || holeNumber === backClosestHole;
+    holeNumber === frontClosestHole ||
+    holeNumber === backClosestHole ||
+    game.closestToPin[holeNumber] !== undefined;
 
   const isEditing = (playerId: string, holeNumber: number) => {
     return (
@@ -405,15 +407,20 @@ const ScoreCard = ({ game, onUpdateScore, onUpdateClosest }: ScoreCardProps) => 
                   {isClosestHole(hole.holeNumber) ? (
                     <select
                       className="text-sm"
-                      value={game.closestToPin[hole.holeNumber] ?? ""}
+                      value={
+                        game.closestToPin[hole.holeNumber] === null
+                          ? "none"
+                          : game.closestToPin[hole.holeNumber] ?? ""
+                      }
                       onChange={(e) =>
                         onUpdateClosest(
                           hole.holeNumber,
-                          e.target.value === "" ? null : e.target.value,
+                          e.target.value === "none" ? null : e.target.value,
                         )
                       }
                     >
-                      <option value="">None</option>
+                      <option value="" disabled>...</option>
+                      <option value="none">None</option>
                       {game.players.map((p) => (
                         <option key={p.id} value={p.id}>
                           {p.name}


### PR DESCRIPTION
## Summary
- keep closest-to-pin dropdowns visible only until a winner is chosen
- remove later closest-to-pin entries when a winner is picked
- show `...` as the default dropdown option

## Testing
- `npm test --silent` *(fails: react-scripts not found)*
- `npm run lint` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861cf4cb1508325bba5a58aff5a5594