### PR TITLE
Add greenies tracking with UI controls

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Game, Player, Course } from './types/golf';
+import { Game, Player, Course, CourseHole } from './types/golf';
 import PlayerSetup from './components/PlayerSetup';
 import ScoreCard from './components/ScoreCard';
 import './App.css';
@@ -7,6 +7,7 @@ import './App.css';
 const calculateSkins = (
   players: Player[],
   closest: Record<number, string | null> = {},
+  greenies: Record<number, Record<string, boolean>> = {},
 ): Player[] => {
   const skinsMap: Record<string, number> = {};
   players.forEach((p) => {
@@ -62,8 +63,43 @@ const calculateSkins = (
   addClosestSkin(frontPar3);
   addClosestSkin(backPar3);
 
+  // Greenies
+  Object.entries(greenies).forEach(([hole, playersMarked]) => {
+    Object.entries(playersMarked).forEach(([id, val]) => {
+      if (val) {
+        skinsMap[id] = (skinsMap[id] || 0) + 1;
+      }
+    });
+  });
+
   return players.map((p) => ({ ...p, skins: skinsMap[p.id] }));
 };
+
+const getGreenieHolesForSide = (
+  holes: CourseHole[],
+  closest: Record<number, string | null>,
+  side: 'front' | 'back',
+): number[] => {
+  const [start, end] = side === 'front' ? [1, 9] : [10, 18];
+  const par3 = holes
+    .filter((h) => h.par === 3 && h.holeNumber >= start && h.holeNumber <= end)
+    .map((h) => h.holeNumber)
+    .sort((a, b) => a - b);
+
+  const awarded = par3.find(
+    (h) => closest[h] !== undefined && closest[h] !== null,
+  );
+  if (awarded === undefined) return [];
+  return par3.filter((h) => h > awarded);
+};
+
+const getGreenieHoles = (
+  holes: CourseHole[],
+  closest: Record<number, string | null>,
+): number[] => [
+  ...getGreenieHolesForSide(holes, closest, 'front'),
+  ...getGreenieHolesForSide(holes, closest, 'back'),
+];
 
 function App() {
   const [game, setGame] = useState<Game | null>(null);
@@ -76,7 +112,8 @@ function App() {
       players: calculateSkins(players),
       currentHole: 1,
       totalHoles: 18,
-      closestToPin: {}
+      closestToPin: {},
+      greenies: {}
     };
 
     setGame(newGame);
@@ -110,6 +147,7 @@ function App() {
     const playersWithSkins = calculateSkins(
       updatedPlayers,
       game.closestToPin,
+      game.greenies,
     );
 
     const updatedGame = {
@@ -145,8 +183,48 @@ function App() {
       }
     }
 
-    const playersWithSkins = calculateSkins(game.players, closest);
-    setGame({ ...game, closestToPin: closest, players: playersWithSkins });
+    const validGreenieHoles = new Set(
+      getGreenieHoles(game.course.holes, closest),
+    );
+    const greenies: Record<number, Record<string, boolean>> = {};
+    Object.entries(game.greenies).forEach(([hole, playersMarked]) => {
+      if (validGreenieHoles.has(Number(hole))) {
+        greenies[Number(hole)] = { ...playersMarked };
+      }
+    });
+
+    const playersWithSkins = calculateSkins(
+      game.players,
+      closest,
+      greenies,
+    );
+    setGame({
+      ...game,
+      closestToPin: closest,
+      greenies,
+      players: playersWithSkins,
+    });
+  };
+
+  const toggleGreenie = (
+    holeNumber: number,
+    playerId: string,
+    value: boolean,
+  ) => {
+    if (!game) return;
+    const validHoles = new Set(
+      getGreenieHoles(game.course.holes, game.closestToPin),
+    );
+    if (!validHoles.has(holeNumber)) return;
+    const holeGreenies = { ...(game.greenies[holeNumber] || {}) };
+    holeGreenies[playerId] = value;
+    const greenies = { ...game.greenies, [holeNumber]: holeGreenies };
+    const playersWithSkins = calculateSkins(
+      game.players,
+      game.closestToPin,
+      greenies,
+    );
+    setGame({ ...game, greenies, players: playersWithSkins });
   };
 
   const resetGame = () => {
@@ -185,6 +263,7 @@ function App() {
               game={game}
               onUpdateScore={updateScore}
               onUpdateClosest={updateClosestToPin}
+              onToggleGreenie={toggleGreenie}
             />
           </div>
         ) : null}

--- a/src/types/golf.ts
+++ b/src/types/golf.ts
@@ -48,4 +48,5 @@ export interface Game {
   currentHole: number;
   totalHoles: number;
   closestToPin: Record<number, string | null>;
+  greenies: Record<number, Record<string, boolean>>;
 }


### PR DESCRIPTION
## Summary
- extend `Game` type with `greenies` data
- count greenie skins in scoring logic
- allow toggling a greenie on the scorecard
- show a narrow green column for par-3 greenies
- wire up new toggle handler in `App`
- only show greenie columns for holes following a Closest to Pin winner
- remove greenie selections if Closest to Pin is cleared

## Testing
- `npm test --silent` *(fails: react-scripts not found)*
- `npx tsc --noEmit` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6861d7b1a4ec83258f3ae52ee94a7037