### PR TITLE
Add Longest Drive skin

### DIFF
--- a/src/types/golf.ts
+++ b/src/types/golf.ts
@@ -48,5 +48,6 @@ export interface Game {
   currentHole: number;
   totalHoles: number;
   closestToPin: Record<number, string | null>;
+  longestDrive: Record<number, string | null>;
   greenies: Record<number, Record<string, boolean>>;
 }


### PR DESCRIPTION
## Summary
- introduce `longestDrive` tracking on `Game`
- add Longest Drive row in `ScoreCard`
- compute Longest Drive skins
- update game logic to handle longest-drive winner selections

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861dec695c88325ae2b43131b16936b