### PR TITLE
Add fiver skin

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@ const calculateSkins = (
   closest: Record<number, string | null> = {},
   longest: Record<number, string | null> = {},
   greenies: Record<number, Record<string, boolean>> = {},
+  fivers: Record<number, Record<string, boolean>> = {},
 ): Player[] => {
   const skinsMap: Record<string, number> = {};
   players.forEach((p) => {
@@ -94,6 +95,15 @@ const calculateSkins = (
     });
   });
 
+  // Fivers
+  Object.entries(fivers).forEach(([hole, playersMarked]) => {
+    Object.entries(playersMarked).forEach(([id, val]) => {
+      if (val) {
+        skinsMap[id] = (skinsMap[id] || 0) + 1;
+      }
+    });
+  });
+
   return players.map((p) => ({ ...p, skins: skinsMap[p.id] }));
 };
 
@@ -136,7 +146,8 @@ function App() {
       totalHoles: 18,
       closestToPin: {},
       longestDrive: {},
-      greenies: {}
+      greenies: {},
+      fivers: {}
     };
 
     setGame(newGame);
@@ -172,6 +183,7 @@ function App() {
       game.closestToPin,
       game.longestDrive,
       game.greenies,
+      game.fivers,
     );
 
     const updatedGame = {
@@ -222,6 +234,7 @@ function App() {
       closest,
       game.longestDrive,
       greenies,
+      game.fivers,
     );
     setGame({
       ...game,
@@ -262,6 +275,7 @@ function App() {
       game.closestToPin,
       longestMap,
       game.greenies,
+      game.fivers,
     );
     setGame({
       ...game,
@@ -288,8 +302,28 @@ function App() {
       game.closestToPin,
       game.longestDrive,
       greenies,
+      game.fivers,
     );
     setGame({ ...game, greenies, players: playersWithSkins });
+  };
+
+  const handleToggleFiver = (
+    holeNumber: number,
+    playerId: string,
+    value: boolean,
+  ) => {
+    if (!game) return;
+    const holeFivers = { ...(game.fivers[holeNumber] || {}) };
+    holeFivers[playerId] = value;
+    const fivers = { ...game.fivers, [holeNumber]: holeFivers };
+    const playersWithSkins = calculateSkins(
+      game.players,
+      game.closestToPin,
+      game.longestDrive,
+      game.greenies,
+      fivers,
+    );
+    setGame({ ...game, fivers, players: playersWithSkins });
   };
 
   const resetGame = () => {
@@ -330,6 +364,7 @@ function App() {
               onUpdateClosest={updateClosestToPin}
               onUpdateLongest={updateLongestDrive}
               onToggleGreenie={handleToggleGreenie}
+              onToggleFiver={handleToggleFiver}
             />
           </div>
         ) : null}

--- a/src/components/ScoreCard.tsx
+++ b/src/components/ScoreCard.tsx
@@ -60,6 +60,7 @@ interface ScoreCardProps {
   onUpdateClosest: (holeNumber: number, playerId: string | null) => void;
   onUpdateLongest: (holeNumber: number, playerId: string | null) => void;
   onToggleGreenie: (holeNumber: number, playerId: string, value: boolean) => void;
+  onToggleFiver: (holeNumber: number, playerId: string, value: boolean) => void;
 }
 
 const ScoreCard = ({
@@ -68,6 +69,7 @@ const ScoreCard = ({
   onUpdateClosest,
   onUpdateLongest,
   onToggleGreenie,
+  onToggleFiver,
 }: ScoreCardProps) => {
   const [editingCell, setEditingCell] = useState<{
     playerId: string;
@@ -322,6 +324,13 @@ const ScoreCard = ({
                       G
                     </th>
                   )}
+                  {hole.par === 5 && (
+                    <th
+                      className="border border-orange-300 bg-orange-50 px-1 py-2 text-center font-semibold text-xs"
+                    >
+                      5
+                    </th>
+                  )}
                 </Fragment>
               ))}
               <th className="border border-gray-300 px-3 py-2 text-center font-semibold">
@@ -406,6 +415,23 @@ const ScoreCard = ({
                             />
                           </td>
                         )}
+                        {hole.par === 5 && (
+                          <td className="border border-orange-300 bg-orange-50 px-1 text-center">
+                            <input
+                              type="checkbox"
+                              checked={
+                                game.fivers[hole.holeNumber]?.[player.id] || false
+                              }
+                              onChange={(e) =>
+                                onToggleFiver(
+                                  hole.holeNumber,
+                                  player.id,
+                                  e.target.checked,
+                                )
+                              }
+                            />
+                          </td>
+                        )}
                       </Fragment>
                     );
                   })}
@@ -463,6 +489,9 @@ const ScoreCard = ({
                           {hole.par === 3 && isGreenieHole(hole.holeNumber) && (
                             <td className="border border-green-300 bg-green-50 px-1" />
                           )}
+                          {hole.par === 5 && (
+                            <td className="border border-orange-300 bg-orange-50 px-1" />
+                          )}
                         </Fragment>
                       );
                     })}
@@ -519,6 +548,9 @@ const ScoreCard = ({
                   {hole.par === 3 && isGreenieHole(hole.holeNumber) && (
                     <td className="border border-green-300 bg-green-50 px-1" />
                   )}
+                  {hole.par === 5 && (
+                    <td className="border border-orange-300 bg-orange-50 px-1" />
+                  )}
                 </Fragment>
               ))}
               <td
@@ -563,6 +595,9 @@ const ScoreCard = ({
                   {hole.par === 3 && isGreenieHole(hole.holeNumber) && (
                     <td className="border border-green-300 bg-green-50 px-1" />
                   )}
+                  {hole.par === 5 && (
+                    <td className="border border-orange-300 bg-orange-50 px-1" />
+                  )}
                 </Fragment>
               ))}
               <td
@@ -593,6 +628,7 @@ const ScoreCard = ({
                     <th className="border px-2 py-1 text-left">Hole</th>
                     <th className="border px-2 py-1 text-center">Strokes</th>
                     <th className="border px-2 py-1 text-center">G</th>
+                    <th className="border px-2 py-1 text-center">5</th>
                     <th className="border px-2 py-1 text-center">Adj</th>
                   </tr>
                 </thead>
@@ -667,6 +703,25 @@ const ScoreCard = ({
                             "-"
                           )}
                         </td>
+                        <td className="border px-2 py-1 text-center">
+                          {hole.par === 5 ? (
+                            <input
+                              type="checkbox"
+                              checked={
+                                game.fivers[hole.holeNumber]?.[player.id] || false
+                              }
+                              onChange={(e) =>
+                                onToggleFiver(
+                                  hole.holeNumber,
+                                  player.id,
+                                  e.target.checked,
+                                )
+                              }
+                            />
+                          ) : (
+                            "-"
+                          )}
+                        </td>
                         <td className="border px-2 py-1 text-center text-sm">
                           {(() => {
                             const adj = getAdjustedScoreForHole(
@@ -691,13 +746,13 @@ const ScoreCard = ({
                   </tr>
                   <tr className="bg-gray-50 font-semibold text-sm">
                     <td className="border px-2 py-1">To Par</td>
-                    <td className="border px-2 py-1 text-center" colSpan={3}>
+                    <td className="border px-2 py-1 text-center" colSpan={4}>
                       {toPar === 0 ? "E" : toPar > 0 ? `+${toPar}` : `${toPar}`}
                     </td>
                   </tr>
                   <tr className="bg-gray-50 font-semibold text-sm">
                     <td className="border px-2 py-1">Skins</td>
-                    <td className="border px-2 py-1 text-center" colSpan={3}>
+                    <td className="border px-2 py-1 text-center" colSpan={4}>
                       {player.skins}
                     </td>
                   </tr>
@@ -707,7 +762,7 @@ const ScoreCard = ({
                         <td className="border px-2 py-1">Adjusted Score</td>
                         <td
                           className="border px-2 py-1 text-center"
-                          colSpan={3}
+                          colSpan={4}
                         >
                           {adjustedScore}
                         </td>
@@ -716,7 +771,7 @@ const ScoreCard = ({
                         <td className="border px-2 py-1">Adjusted To Par</td>
                         <td
                           className="border px-2 py-1 text-center"
-                          colSpan={3}
+                          colSpan={4}
                         >
                           {adjustedToPar === 0
                             ? "E"

--- a/src/types/golf.ts
+++ b/src/types/golf.ts
@@ -50,4 +50,5 @@ export interface Game {
   closestToPin: Record<number, string | null>;
   longestDrive: Record<number, string | null>;
   greenies: Record<number, Record<string, boolean>>;
+  fivers: Record<number, Record<string, boolean>>;
 }


### PR DESCRIPTION
## Summary
- add `fivers` to `Game` type
- compute fiver skins in App logic
- allow toggling fiver skins in ScoreCard
- render fiver column next to par 5 holes

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861e11f552c8325b7cfcd0698c45919