### PR TITLE
Add four skin feature

### DIFF
--- a/src/types/golf.ts
+++ b/src/types/golf.ts
@@ -51,4 +51,5 @@ export interface Game {
   longestDrive: Record<number, string | null>;
   greenies: Record<number, Record<string, boolean>>;
   fivers: Record<number, Record<string, boolean>>;
+  fours: Record<number, Record<string, boolean>>;
 }


### PR DESCRIPTION
## Summary
- introduce `fourSkins` data on `Game`
- support fours in skin calculations and toggles
- display a new blue "4" column on the scorecard for the lowest-handicap par‑4 on each side

## Testing
- `npm test --silent` *(fails: react-scripts not found)*
- `npx tsc -p tsconfig.json` *(fails to run due to missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_686325ddd6e48325b57d511891775cbc