### PR TITLE
Improve score cell styling on mobile

### DIFF
--- a/src/components/ScoreCard.tsx
+++ b/src/components/ScoreCard.tsx
@@ -427,11 +427,11 @@ const ScoreCard = ({
                           onKeyPress={(e) =>
                             e.key === "Enter" && handleCellChange(editingValue)
                           }
-                          className="w-12 text-center"
+                          className="score-input"
                         />
                       ) : (
                         <button
-                          className={`w-10 h-10 md:w-8 md:h-8 mx-auto flex items-center justify-center ${getScoreColor(
+                          className={`score-button hover:bg-gray-200 ${getScoreColor(
                             value,
                             hole.par,
                           )} ${getScoreBorderStyle(value, hole.par)}`}
@@ -1035,14 +1035,14 @@ const ScoreCard = ({
                             onChange={handleInputChange}
                             onBlur={(e) => handleCellChange(e.target.value)}
                             onKeyPress={(e) => e.key === 'Enter' && handleCellChange(editingValue)}
-                            className="w-12 text-center"
-                          />
-                        ) : (
-                          <button
-                            className={`w-10 h-10 md:w-8 md:h-8 mx-auto flex items-center justify-center ${getScoreColor(phole.strokes, phole.par)} ${getScoreBorderStyle(phole.strokes, phole.par)}`}
-                            style={{
-                              ...getDoubleCircleStyle(phole.strokes, phole.par),
-                              ...getDoubleSquareStyle(phole.strokes, phole.par),
+                          className="score-input"
+                        />
+                      ) : (
+                        <button
+                          className={`score-button hover:bg-gray-200 ${getScoreColor(phole.strokes, phole.par)} ${getScoreBorderStyle(phole.strokes, phole.par)}`}
+                          style={{
+                            ...getDoubleCircleStyle(phole.strokes, phole.par),
+                            ...getDoubleSquareStyle(phole.strokes, phole.par),
                               ...getCrossHatchStyle(phole.strokes, phole.par),
                             }}
                             onClick={() => handleCellClick(player.id, hole.holeNumber)}

--- a/src/index.css
+++ b/src/index.css
@@ -30,4 +30,12 @@ code {
   .golf-input {
     @apply border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-golf-green focus:border-transparent;
   }
+
+  .score-input {
+    @apply w-12 h-12 md:w-8 md:h-8 text-center rounded-md bg-gray-100 border border-gray-300 focus:bg-white focus:outline-none focus:ring-2 focus:ring-golf-green;
+  }
+
+  .score-button {
+    @apply w-12 h-12 md:w-8 md:h-8 mx-auto flex items-center justify-center rounded-md cursor-pointer transition-colors;
+  }
 }


### PR DESCRIPTION
## Summary
- add reusable `score-input` and `score-button` styles
- apply styles to scorecard editing widgets for mobile friendliness

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_686590b3fc388325a68d5aa9a76e4c1a