### PR TITLE
Add player profile icons

### DIFF
--- a/src/components/PlayerIcon.tsx
+++ b/src/components/PlayerIcon.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+
+interface PlayerIconProps {
+  name: string;
+  color?: string;
+  size?: number;
+}
+
+const PlayerIcon = ({ name, color = '#ccc', size = 24 }: PlayerIconProps) => {
+  const initial = name ? name.charAt(0).toUpperCase() : '';
+  return (
+    <div
+      style={{ backgroundColor: color, width: size, height: size }}
+      className="rounded-full flex items-center justify-center text-white font-bold"
+    >
+      {initial}
+    </div>
+  );
+};
+
+export default PlayerIcon;

--- a/src/components/PlayerSetup.tsx
+++ b/src/components/PlayerSetup.tsx
@@ -6,17 +6,20 @@ import {
 } from '../services/courseService';
 import CourseSelector from './CourseSelector';
 import CourseEditor from './CourseEditor';
+import PlayerIcon from './PlayerIcon';
 
 interface PlayerSetupProps {
   onStartGame: (players: Player[], course: Course) => void;
 }
 
 const PlayerSetup = ({ onStartGame }: PlayerSetupProps) => {
+  const getRandomColor = () =>
+    `#${Math.floor(Math.random() * 0xffffff).toString(16).padStart(6, '0')}`;
   const [players, setPlayers] = useState<PlayerSetupType[]>([
     { id: '1', name: '' },
     { id: '2', name: '' },
     { id: '3', name: '' },
-    { id: '4', name: '' }
+    { id: '4', name: '' },
   ]);
   const [selectedCourse, setSelectedCourse] = useState<Course | null>(null);
   const [activePlayers, setActivePlayers] = useState(2);
@@ -30,7 +33,21 @@ const PlayerSetup = ({ onStartGame }: PlayerSetupProps) => {
     value: string,
   ) => {
     setPlayers((prev) =>
-      prev.map((player) => (player.id === id ? { ...player, [field]: value } : player)),
+      prev.map((player) => {
+        if (player.id !== id) return player;
+        const updated: PlayerSetupType = { ...player, [field]: value };
+        if (
+          field === 'name' &&
+          value.trim() !== '' &&
+          !player.color
+        ) {
+          updated.color = getRandomColor();
+        }
+        if (field === 'name' && value.trim() === '') {
+          updated.color = undefined;
+        }
+        return updated;
+      }),
     );
   };
 
@@ -196,13 +213,18 @@ const PlayerSetup = ({ onStartGame }: PlayerSetupProps) => {
                   <label className="block text-sm font-medium text-gray-700 mb-1">
                     Player {index + 1} Name
                   </label>
-                  <input
-                    type="text"
-                    value={player.name}
-                    onChange={(e) => updatePlayer(player.id, 'name', e.target.value)}
-                    placeholder={`Player ${index + 1}`}
-                    className="golf-input w-full"
-                  />
+                  <div className="flex items-center space-x-3">
+                    <PlayerIcon name={player.name} color={player.color} size={32} />
+                    <input
+                      type="text"
+                      value={player.name}
+                      onChange={(e) =>
+                        updatePlayer(player.id, 'name', e.target.value)
+                      }
+                      placeholder={`Player ${index + 1}`}
+                      className="golf-input w-full"
+                    />
+                  </div>
                 </div>
               </div>
             ))}

--- a/src/components/ScoreCard.tsx
+++ b/src/components/ScoreCard.tsx
@@ -1,6 +1,7 @@
 import { useState, Fragment } from "react";
 import type { ChangeEvent } from "react";
 import { Game, Player, HoleScore, CourseHole } from "../types/golf";
+import PlayerIcon from "./PlayerIcon";
 
 const HOLE_COL_WIDTH = "w-12";
 const SKIN_COL_WIDTH = "w-6";
@@ -403,7 +404,10 @@ const ScoreCard = ({
               <td
                 className={`border border-gray-300 px-3 py-2 font-medium ${PLAYER_COL_WIDTH}`}
               >
-                {player.name}
+                <div className="flex items-center space-x-2">
+                  <PlayerIcon name={player.name} color={player.color} size={24} />
+                  <span>{player.name}</span>
+                </div>
               </td>
               {holes.map((hole) => {
                 const value = player.holes.find(
@@ -961,7 +965,12 @@ const ScoreCard = ({
       <tbody>
         {game.players.map((player, idx) => (
           <tr key={player.id} className={idx % 2 === 0 ? "bg-white" : "bg-gray-50"}>
-            <td className={`border border-gray-300 px-3 py-2 font-medium ${PLAYER_COL_WIDTH}`}>{player.name}</td>
+            <td className={`border border-gray-300 px-3 py-2 font-medium ${PLAYER_COL_WIDTH}`}>
+              <div className="flex items-center space-x-2">
+                <PlayerIcon name={player.name} color={player.color} size={24} />
+                <span>{player.name}</span>
+              </div>
+            </td>
             <td className={`border border-gray-300 px-3 py-2 text-center font-bold bg-blue-100 ${TOTAL_COL_WIDTH}`}>{player.totalScore}</td>
             <td className={`border border-gray-300 px-3 py-2 text-center font-bold bg-purple-100 ${TOTAL_COL_WIDTH}`}>{(() => {const t = calculateTotalToPar(player); if (t === 0) return 'E'; return t > 0 ? `+${t}` : `${t}`;})()}</td>
             <td className={`border border-gray-300 px-3 py-2 text-center font-bold bg-green-100 ${TOTAL_COL_WIDTH}`}>{player.skins}</td>
@@ -1001,7 +1010,10 @@ const ScoreCard = ({
                   key={player.id}
                   className={`border border-gray-300 px-2 py-2 text-center font-semibold ${PLAYER_COL_WIDTH}`}
                 >
-                  {player.name}
+                  <div className="flex items-center space-x-1 justify-center">
+                    <PlayerIcon name={player.name} color={player.color} size={20} />
+                    <span>{player.name}</span>
+                  </div>
                 </th>
               ))}
               <th

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -2,3 +2,4 @@ export { default as CourseEditor } from './CourseEditor';
 export { default as CourseSelector } from './CourseSelector';
 export { default as PlayerSetup } from './PlayerSetup';
 export { default as ScoreCard } from './ScoreCard';
+export { default as PlayerIcon } from './PlayerIcon';

--- a/src/types/golf.ts
+++ b/src/types/golf.ts
@@ -1,11 +1,13 @@
 export interface PlayerSetup {
   id: string;
   name: string;
+  color?: string;
 }
 
 export interface Player {
   id: string;
   name: string;
+  color?: string;
   totalScore: number;
   totalPutts: number;
   skins: number;


### PR DESCRIPTION
## Summary
- add PlayerIcon component for colored initials
- allow players to get random profile icon colors during setup
- display icons in setup and on the scorecard
- update types to include optional color

## Testing
- `npm test --silent` *(fails: react-scripts not found)*
- `npx tsc -p tsconfig.json` *(fails: cannot find module declarations)*

------
https://chatgpt.com/codex/tasks/task_e_6865a6333ef48325a797d1429d68098d