### PR TITLE
Update mobile winner styling

### DIFF
--- a/src/components/PlayerIcon.tsx
+++ b/src/components/PlayerIcon.tsx
@@ -11,7 +11,7 @@ const PlayerIcon = ({ name, color = '#ccc', size = 24, onClick }: PlayerIconProp
   return (
     <div
       style={{ backgroundColor: color, width: size, height: size }}
-      className={`rounded-full flex items-center justify-center text-white font-bold ${
+      className={`rounded-full flex items-center justify-center text-white font-bold select-none ${
         onClick ? 'cursor-pointer' : ''
       }`}
       onClick={onClick}

--- a/src/components/ScoreCard.tsx
+++ b/src/components/ScoreCard.tsx
@@ -206,6 +206,20 @@ const ScoreCard = ({
     return hole ? hole.strokes <= hole.par && hole.strokes > 0 : false;
   };
 
+  const isHoleWinner = (holeNumber: number, playerId: string) => {
+    const scores = game.players
+      .map((p) => ({
+        id: p.id,
+        strokes:
+          p.holes.find((h) => h.holeNumber === holeNumber)?.strokes || 0,
+      }))
+      .filter((s) => s.strokes > 0);
+    if (scores.length === 0) return false;
+    const min = Math.min(...scores.map((s) => s.strokes));
+    const winners = scores.filter((s) => s.strokes === min);
+    return winners.length === 1 && winners[0].id === playerId;
+  };
+
   const getGreenieHolesForSide = (
     holes: CourseHole[],
     closest: Record<number, string | null>,
@@ -1069,16 +1083,18 @@ const ScoreCard = ({
                         />
                       ) : (
                         <button
-                          className={`score-button hover:bg-gray-200 ${getScoreColor(phole.strokes, phole.par)} ${getScoreBorderStyle(phole.strokes, phole.par)}`}
+                          className={`score-button hover:bg-gray-200 ${getScoreColor(phole.strokes, phole.par)} ${getScoreBorderStyle(phole.strokes, phole.par)} ${
+                            isHoleWinner(hole.holeNumber, player.id) ? 'text-xl font-bold' : ''
+                          }`}
                           style={{
                             ...getDoubleCircleStyle(phole.strokes, phole.par),
                             ...getDoubleSquareStyle(phole.strokes, phole.par),
-                              ...getCrossHatchStyle(phole.strokes, phole.par),
-                            }}
-                            onClick={() => handleCellClick(player.id, hole.holeNumber)}
-                          >
-                            {getScoreDisplay(phole.strokes, phole.par)}
-                          </button>
+                            ...getCrossHatchStyle(phole.strokes, phole.par),
+                          }}
+                          onClick={() => handleCellClick(player.id, hole.holeNumber)}
+                        >
+                          {getScoreDisplay(phole.strokes, phole.par)}
+                        </button>
                         )}
                       </td>
                     );


### PR DESCRIPTION
## Summary
- prevent selecting text inside player icons
- highlight mobile hole winners with larger, bold text

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865abb241b883258864e7caa52be42a