### PR TITLE
Replace dropdowns with popover player icons

### DIFF
--- a/src/components/PlayerSelect.tsx
+++ b/src/components/PlayerSelect.tsx
@@ -1,0 +1,79 @@
+import { useState, useRef, useEffect } from 'react';
+import { Player } from '../types/golf';
+import PlayerIcon from './PlayerIcon';
+
+interface PlayerSelectProps {
+  players: Player[];
+  selected?: string | null;
+  onSelect: (playerId: string | null) => void;
+}
+
+const PlayerSelect = ({ players, selected, onSelect }: PlayerSelectProps) => {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const handle = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener('click', handle);
+    return () => document.removeEventListener('click', handle);
+  }, [open]);
+
+  const selectedPlayer = players.find((p) => p.id === selected);
+
+  return (
+    <div className="relative inline-flex items-center" ref={ref}>
+      {selected === null ? (
+        <div
+          className="w-6 h-6 bg-gray-300 rounded-full flex items-center justify-center cursor-pointer"
+          onClick={() => setOpen(!open)}
+        >
+          <span className="text-lg font-bold">×</span>
+        </div>
+      ) : selectedPlayer ? (
+        <PlayerIcon
+          name={selectedPlayer.name}
+          color={selectedPlayer.color}
+          size={24}
+          onClick={() => setOpen(!open)}
+        />
+      ) : (
+        <div
+          className="w-6 h-6 bg-gray-300 rounded-full cursor-pointer"
+          onClick={() => setOpen(!open)}
+        />
+      )}
+      {open && (
+        <div className="absolute left-1/2 -translate-x-1/2 mt-1 z-20 bg-white border border-gray-300 rounded shadow p-1 flex space-x-1">
+          <div
+            className="w-6 h-6 bg-gray-300 rounded-full flex items-center justify-center cursor-pointer"
+            onClick={() => {
+              onSelect(null);
+              setOpen(false);
+            }}
+          >
+            <span className="text-lg font-bold">×</span>
+          </div>
+          {players.map((p) => (
+            <PlayerIcon
+              key={p.id}
+              name={p.name}
+              color={p.color}
+              size={24}
+              onClick={() => {
+                onSelect(p.id);
+                setOpen(false);
+              }}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default PlayerSelect;

--- a/src/components/ScoreCard.tsx
+++ b/src/components/ScoreCard.tsx
@@ -2,6 +2,7 @@ import { useState, Fragment } from "react";
 import type { ChangeEvent } from "react";
 import { Game, Player, HoleScore, CourseHole } from "../types/golf";
 import PlayerIcon from "./PlayerIcon";
+import PlayerSelect from "./PlayerSelect";
 
 const HOLE_COL_WIDTH = "w-12";
 const SKIN_COL_WIDTH = "w-6";
@@ -660,35 +661,16 @@ const ScoreCard = ({
           {holes.map((hole) => (
             <Fragment key={hole.holeNumber}>
               <td
-                className={`border border-gray-300 px-2 py-1 text-center ${
+                className={`border border-gray-300 px-2 py-1 text-center align-middle ${
                   hole.holeNumber === 10 ? "border-l-4" : ""
                 } ${HOLE_COL_WIDTH}`}
               >
                 {isClosestHole(hole.holeNumber) ? (
-                  <select
-                    className="text-sm w-full"
-                    value={
-                      game.closestToPin[hole.holeNumber] === null
-                        ? "none"
-                        : game.closestToPin[hole.holeNumber] ?? ""
-                    }
-                    onChange={(e) =>
-                      onUpdateClosest(
-                        hole.holeNumber,
-                        e.target.value === "none" ? null : e.target.value,
-                      )
-                    }
-                  >
-                    <option value="" disabled>
-                      ...
-                    </option>
-                    <option value="none">None</option>
-                    {game.players.map((p) => (
-                      <option key={p.id} value={p.id}>
-                        {p.name}
-                      </option>
-                    ))}
-                  </select>
+                  <PlayerSelect
+                    players={game.players}
+                    selected={game.closestToPin[hole.holeNumber]}
+                    onSelect={(id) => onUpdateClosest(hole.holeNumber, id)}
+                  />
                 ) : null}
               </td>
               {hole.par === 3 &&
@@ -742,35 +724,16 @@ const ScoreCard = ({
           {holes.map((hole) => (
             <Fragment key={hole.holeNumber}>
               <td
-                className={`border border-gray-300 px-2 py-1 text-center ${
+                className={`border border-gray-300 px-2 py-1 text-center align-middle ${
                   hole.holeNumber === 10 ? "border-l-4" : ""
                 } ${HOLE_COL_WIDTH}`}
               >
                 {isLongestHole(hole.holeNumber) ? (
-                  <select
-                    className="text-sm w-full"
-                    value={
-                      game.longestDrive[hole.holeNumber] === null
-                        ? "none"
-                        : game.longestDrive[hole.holeNumber] ?? ""
-                    }
-                    onChange={(e) =>
-                      onUpdateLongest(
-                        hole.holeNumber,
-                        e.target.value === "none" ? null : e.target.value,
-                      )
-                    }
-                  >
-                    <option value="" disabled>
-                      ...
-                    </option>
-                    <option value="none">None</option>
-                    {game.players.map((p) => (
-                      <option key={p.id} value={p.id}>
-                        {p.name}
-                      </option>
-                    ))}
-                  </select>
+                  <PlayerSelect
+                    players={game.players}
+                    selected={game.longestDrive[hole.holeNumber]}
+                    onSelect={(id) => onUpdateLongest(hole.holeNumber, id)}
+                  />
                 ) : null}
               </td>
               {hole.par === 3 &&
@@ -1099,60 +1062,22 @@ const ScoreCard = ({
                       </td>
                     );
                   })}
-                  <td className={`border border-gray-300 px-1 text-center ${SKIN_COL_WIDTH}`}>
+                  <td className={`border border-gray-300 px-1 text-center align-middle ${SKIN_COL_WIDTH}`}>
                     {isClosestHole(hole.holeNumber) ? (
-                      <select
-                        className="text-sm w-full"
-                        value={
-                          game.closestToPin[hole.holeNumber] === null
-                            ? 'none'
-                            : game.closestToPin[hole.holeNumber] ?? ''
-                        }
-                        onChange={(e) =>
-                          onUpdateClosest(
-                            hole.holeNumber,
-                            e.target.value === 'none' ? null : e.target.value,
-                          )
-                        }
-                      >
-                        <option value="" disabled>
-                          ...
-                        </option>
-                        <option value="none">None</option>
-                        {game.players.map((p) => (
-                          <option key={p.id} value={p.id}>
-                            {p.name}
-                          </option>
-                        ))}
-                      </select>
+                      <PlayerSelect
+                        players={game.players}
+                        selected={game.closestToPin[hole.holeNumber]}
+                        onSelect={(id) => onUpdateClosest(hole.holeNumber, id)}
+                      />
                     ) : null}
                   </td>
-                  <td className={`border border-gray-300 px-1 text-center ${SKIN_COL_WIDTH}`}>
+                  <td className={`border border-gray-300 px-1 text-center align-middle ${SKIN_COL_WIDTH}`}>
                     {isLongestHole(hole.holeNumber) ? (
-                      <select
-                        className="text-sm w-full"
-                        value={
-                          game.longestDrive[hole.holeNumber] === null
-                            ? 'none'
-                            : game.longestDrive[hole.holeNumber] ?? ''
-                        }
-                        onChange={(e) =>
-                          onUpdateLongest(
-                            hole.holeNumber,
-                            e.target.value === 'none' ? null : e.target.value,
-                          )
-                        }
-                      >
-                        <option value="" disabled>
-                          ...
-                        </option>
-                        <option value="none">None</option>
-                        {game.players.map((p) => (
-                          <option key={p.id} value={p.id}>
-                            {p.name}
-                          </option>
-                        ))}
-                      </select>
+                      <PlayerSelect
+                        players={game.players}
+                        selected={game.longestDrive[hole.holeNumber]}
+                        onSelect={(id) => onUpdateLongest(hole.holeNumber, id)}
+                      />
                     ) : null}
                   </td>
                   <td className={`border border-gray-300 px-1 text-center ${SKIN_COL_WIDTH}`}>

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -3,3 +3,4 @@ export { default as CourseSelector } from './CourseSelector';
 export { default as PlayerSetup } from './PlayerSetup';
 export { default as ScoreCard } from './ScoreCard';
 export { default as PlayerIcon } from './PlayerIcon';
+export { default as PlayerSelect } from './PlayerSelect';


### PR DESCRIPTION
## Summary
- add `PlayerSelect` component for icon-based selection
- use `PlayerSelect` instead of `<select>` for CTP and LD rows
- vertically center the player selector icons
- export new component

## Testing
- `npm test --silent --run-tests` *(fails: react-scripts not found)*
- `npm run lint --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865ae295e188325bbf3730691554873