### PR TITLE
Increase player icon size in popovers

### DIFF
--- a/src/components/PlayerSelect.tsx
+++ b/src/components/PlayerSelect.tsx
@@ -50,7 +50,7 @@ const PlayerSelect = ({ players, selected, onSelect }: PlayerSelectProps) => {
       {open && (
         <div className="absolute left-1/2 -translate-x-1/2 mt-1 z-20 bg-white border border-gray-300 rounded shadow p-1 flex space-x-1">
           <div
-            className="w-6 h-6 bg-gray-300 rounded-full flex items-center justify-center cursor-pointer"
+            className="w-8 h-8 bg-gray-300 rounded-full flex items-center justify-center cursor-pointer"
             onClick={() => {
               onSelect(null);
               setOpen(false);
@@ -63,7 +63,7 @@ const PlayerSelect = ({ players, selected, onSelect }: PlayerSelectProps) => {
               key={p.id}
               name={p.name}
               color={p.color}
-              size={24}
+              size={32}
               onClick={() => {
                 onSelect(p.id);
                 setOpen(false);

--- a/src/components/ScoreCard.tsx
+++ b/src/components/ScoreCard.tsx
@@ -661,7 +661,7 @@ const ScoreCard = ({
           {holes.map((hole) => (
             <Fragment key={hole.holeNumber}>
               <td
-                className={`border border-gray-300 px-2 py-1 text-center ${
+                className={`border border-gray-300 px-2 py-1 text-center align-middle ${
                   hole.holeNumber === 10 ? "border-l-4" : ""
                 } ${HOLE_COL_WIDTH}`}
               >
@@ -724,7 +724,7 @@ const ScoreCard = ({
           {holes.map((hole) => (
             <Fragment key={hole.holeNumber}>
               <td
-                className={`border border-gray-300 px-2 py-1 text-center ${
+                className={`border border-gray-300 px-2 py-1 text-center align-middle ${
                   hole.holeNumber === 10 ? "border-l-4" : ""
                 } ${HOLE_COL_WIDTH}`}
               >
@@ -1062,7 +1062,7 @@ const ScoreCard = ({
                       </td>
                     );
                   })}
-                  <td className={`border border-gray-300 px-1 text-center ${SKIN_COL_WIDTH}`}>
+                  <td className={`border border-gray-300 px-1 text-center align-middle ${SKIN_COL_WIDTH}`}>
                     {isClosestHole(hole.holeNumber) ? (
                       <PlayerSelect
                         players={game.players}
@@ -1071,7 +1071,7 @@ const ScoreCard = ({
                       />
                     ) : null}
                   </td>
-                  <td className={`border border-gray-300 px-1 text-center ${SKIN_COL_WIDTH}`}>
+                  <td className={`border border-gray-300 px-1 text-center align-middle ${SKIN_COL_WIDTH}`}>
                     {isLongestHole(hole.holeNumber) ? (
                       <PlayerSelect
                         players={game.players}


### PR DESCRIPTION
## Summary
- enlarge the player selector popover icons so they're easier to tap
- vertically center player select placeholders in skin rows

## Testing
- `npm test --silent` *(fails: react-scripts not found)*


------
https://chatgpt.com/codex/tasks/task_e_6865b217c62c832595ba3cc2901984ec