### PR TITLE
Improve mobile scorecard layout

### DIFF
--- a/src/components/PlayerHeader.tsx
+++ b/src/components/PlayerHeader.tsx
@@ -1,0 +1,39 @@
+import { useRef, useEffect, useState } from 'react';
+import { Player } from '../types/golf';
+import PlayerIcon from './PlayerIcon';
+
+interface PlayerHeaderProps {
+  player: Player;
+  iconSize: number;
+  textClass: string;
+}
+
+const PlayerHeader = ({ player, iconSize, textClass }: PlayerHeaderProps) => {
+  const spanRef = useRef<HTMLSpanElement>(null);
+  const [overflow, setOverflow] = useState(false);
+
+  useEffect(() => {
+    const checkOverflow = () => {
+      const el = spanRef.current;
+      if (el) {
+        setOverflow(el.scrollWidth > el.clientWidth);
+      }
+    };
+    checkOverflow();
+    window.addEventListener('resize', checkOverflow);
+    return () => window.removeEventListener('resize', checkOverflow);
+  }, [player.name]);
+
+  return overflow ? (
+    <div className="flex items-center justify-center">
+      <PlayerIcon name={player.name} color={player.color} size={iconSize} />
+    </div>
+  ) : (
+    <div className="flex items-center space-x-1 justify-center">
+      <PlayerIcon name={player.name} color={player.color} size={iconSize} />
+      <span ref={spanRef} className={`truncate ${textClass}`}>{player.name}</span>
+    </div>
+  );
+};
+
+export default PlayerHeader;

--- a/src/components/ScoreCard.tsx
+++ b/src/components/ScoreCard.tsx
@@ -2,6 +2,7 @@ import { useState, Fragment } from "react";
 import type { ChangeEvent } from "react";
 import { Game, Player, HoleScore, CourseHole } from "../types/golf";
 import PlayerIcon from "./PlayerIcon";
+import PlayerHeader from "./PlayerHeader";
 import PlayerSelect from "./PlayerSelect";
 
 const HOLE_COL_WIDTH = "w-12";
@@ -170,18 +171,8 @@ const ScoreCard = ({
     if (n === 6) return "px-1";
     return "px-0.5";
   };
-  const getMobileScoreSizeClass = (n: number) => {
-    if (n <= 3) return "w-12 h-12";
-    if (n === 4) return "w-10 h-10";
-    if (n === 5) return "w-8 h-8";
-    if (n === 6) return "w-8 h-8";
-    if (n === 7) return "w-6 h-6";
-    if (n === 8) return "w-6 h-6";
-    return "w-5 h-5";
-  };
   const mobilePlayerWidthClass = getMobilePlayerWidthClass(numPlayers);
   const mobilePlayerPaddingClass = getMobilePlayerPaddingClass(numPlayers);
-  const mobileScoreSizeClass = getMobileScoreSizeClass(numPlayers);
   const mobileHeaderTextClass = numPlayers >= 7 ? "text-[10px]" : numPlayers > 4 ? "text-xs" : "";
   const mobileIconSize = numPlayers >= 7 ? 12 : numPlayers > 4 ? 16 : 20;
 
@@ -1020,10 +1011,11 @@ const ScoreCard = ({
                   key={player.id}
                   className={`border border-gray-300 ${mobilePlayerPaddingClass} md:px-2 py-2 text-center font-semibold ${PLAYER_COL_WIDTH} ${mobilePlayerWidthClass}`}
                 >
-                  <div className="flex items-center space-x-1 justify-center">
-                    <PlayerIcon name={player.name} color={player.color} size={mobileIconSize} />
-                    <span className={`truncate ${mobileHeaderTextClass}`}>{player.name}</span>
-                  </div>
+                  <PlayerHeader
+                    player={player}
+                    iconSize={mobileIconSize}
+                    textClass={mobileHeaderTextClass}
+                  />
                 </th>
               ))}
               <th
@@ -1074,12 +1066,12 @@ const ScoreCard = ({
                             onChange={handleInputChange}
                             onBlur={(e) => handleCellChange(e.target.value)}
                             onKeyPress={(e) => e.key === 'Enter' && handleCellChange(editingValue)}
-                          className={`score-input ${mobileScoreSizeClass}`}
+                          className="score-input"
                           autoFocus
                         />
                       ) : (
                         <button
-                          className={`score-button hover:bg-gray-200 ${mobileScoreSizeClass} ${getScoreColor(phole.strokes, phole.par)} ${getScoreBorderStyle(phole.strokes, phole.par)} ${
+                          className={`score-button hover:bg-gray-200 ${getScoreColor(phole.strokes, phole.par)} ${getScoreBorderStyle(phole.strokes, phole.par)} ${
                             isHoleWinner(hole.holeNumber, player.id) ? 'text-xl font-bold' : ''
                           }`}
                           style={{

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -4,3 +4,4 @@ export { default as PlayerSetup } from './PlayerSetup';
 export { default as ScoreCard } from './ScoreCard';
 export { default as PlayerIcon } from './PlayerIcon';
 export { default as PlayerSelect } from './PlayerSelect';
+export { default as PlayerHeader } from './PlayerHeader';

--- a/src/index.css
+++ b/src/index.css
@@ -32,10 +32,10 @@ code {
   }
 
   .score-input {
-    @apply w-12 h-12 md:w-8 md:h-8 text-center rounded-md bg-gray-100 border border-gray-300 focus:bg-white focus:outline-none focus:ring-2 focus:ring-golf-green;
+    @apply w-full h-full aspect-square text-center rounded-md bg-gray-100 border border-gray-300 focus:bg-white focus:outline-none focus:ring-2 focus:ring-golf-green;
   }
 
   .score-button {
-    @apply w-12 h-12 md:w-8 md:h-8 mx-auto flex items-center justify-center rounded-md cursor-pointer transition-colors;
+    @apply w-full h-full aspect-square mx-auto flex items-center justify-center rounded-md cursor-pointer transition-colors;
   }
 }


### PR DESCRIPTION
## Summary
- hide long player names on mobile using new `PlayerHeader`
- size score buttons and inputs dynamically to fit inside cells

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865d48ec1d883259bd889f079b20afe