### PR TITLE
Improve scorecard styling and add animations

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -609,7 +609,7 @@ function App() {
   };
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-green-400 to-blue-500">
+    <div className="min-h-screen bg-gradient-to-br from-green-400 to-blue-500 fade-in">
       <div className="container mx-auto px-4 py-8">
         <header className="text-center mb-8">
           <h1 className="text-4xl font-bold text-white mb-2">🏌️ The Tour</h1>

--- a/src/features/course/CourseEditor.tsx
+++ b/src/features/course/CourseEditor.tsx
@@ -133,7 +133,7 @@ const CourseEditor = ({ course, onSaveCourse, onCancel, onDeleteCourse }: Course
   const isCustomCourse = course.id !== 'pebble-beach' && course.id !== 'augusta-national' && course.id !== 'st-andrews-old';
 
   return (
-    <div className="golf-card max-w-4xl mx-auto">
+    <div className="golf-card fade-in max-w-4xl mx-auto">
       <div className="flex justify-between items-center mb-4">
         <h2 className="text-xl font-bold text-gray-800">Course Editor</h2>
         <div className="flex space-x-2">

--- a/src/features/player/PlayerIcon.tsx
+++ b/src/features/player/PlayerIcon.tsx
@@ -11,8 +11,8 @@ const PlayerIcon = ({ name, color = '#ccc', size = 24, onClick }: PlayerIconProp
   return (
     <div
       style={{ backgroundColor: color, width: size, height: size }}
-      className={`rounded-full flex items-center justify-center text-white font-bold select-none ${
-        onClick ? 'cursor-pointer' : ''
+      className={`rounded-full flex items-center justify-center text-white font-bold select-none transition-transform duration-200 ${
+        onClick ? 'cursor-pointer hover:scale-105 active:scale-95' : ''
       }`}
       onClick={onClick}
     >

--- a/src/features/player/PlayerSetup.tsx
+++ b/src/features/player/PlayerSetup.tsx
@@ -168,7 +168,7 @@ const PlayerSetup = ({ onStartGame }: PlayerSetupProps) => {
   }
 
   return (
-    <div className="golf-card max-w-2xl mx-auto">
+    <div className="golf-card fade-in max-w-2xl mx-auto">
       <h2 className="text-2xl font-bold text-gray-800 mb-6">Game Setup</h2>
       
       <div className="space-y-6">

--- a/src/features/score/ScoreCard.tsx
+++ b/src/features/score/ScoreCard.tsx
@@ -346,7 +346,7 @@ const renderDesktopTable = (
   holes: CourseHole[],
   includeTotals: boolean,
 ) => (
-    <table className="w-full table-fixed border-collapse">
+    <table className="w-full table-fixed border-collapse divide-y divide-gray-200">
       <thead>
         <tr className="bg-gray-100">
           <th
@@ -362,7 +362,7 @@ const renderDesktopTable = (
           {holes.map((hole) => (
             <Fragment key={hole.holeNumber}>
               <th
-                className={`border border-gray-300 px-2 py-2 text-center font-semibold text-sm ${
+                className={`border border-gray-300 px-2 py-2 text-center font-semibold text-sm font-mono ${
                   hole.holeNumber === 10 ? "border-l-4" : ""
                 } ${HOLE_COL_WIDTH}`}
               >
@@ -450,7 +450,7 @@ const renderDesktopTable = (
                 </div>
               </td>
               <td
-                className={`border border-gray-300 px-3 py-2 text-center font-bold bg-green-100 ${TOTAL_COL_WIDTH}`}
+                className={`border border-gray-300 px-3 py-2 text-center font-bold bg-green-100 ${TOTAL_COL_WIDTH} font-mono`}
               >
                 {player.skins}
               </td>
@@ -662,12 +662,12 @@ const renderDesktopTable = (
               {includeTotals && (
                 <>
                   <td
-                    className={`border border-gray-300 px-3 py-2 text-center font-bold bg-blue-100 ${TOTAL_COL_WIDTH}`}
+                    className={`border border-gray-300 px-3 py-2 text-center font-bold bg-blue-100 ${TOTAL_COL_WIDTH} font-mono`}
                   >
                     {player.totalScore}
                   </td>
                   <td
-                    className={`border border-gray-300 px-3 py-2 text-center font-bold bg-purple-100 ${TOTAL_COL_WIDTH}`}
+                    className={`border border-gray-300 px-3 py-2 text-center font-bold bg-purple-100 ${TOTAL_COL_WIDTH} font-mono`}
                   >
                     {(() => {
                       const toPar = calculateTotalToPar(player);
@@ -943,7 +943,7 @@ const renderDesktopTable = (
   );
 
   const renderTotalsTable = () => (
-    <table className="w-full table-fixed border-collapse mt-4">
+    <table className="w-full table-fixed border-collapse divide-y divide-gray-200 mt-4">
       <thead>
         <tr className="bg-gray-100">
           <th
@@ -981,11 +981,11 @@ const renderDesktopTable = (
                 <span>{player.name}</span>
               </div>
             </td>
-            <td className={`border border-gray-300 px-3 py-2 text-center font-bold bg-green-100 ${TOTAL_COL_WIDTH}`}>{player.skins}</td>
+            <td className={`border border-gray-300 px-3 py-2 text-center font-bold bg-green-100 ${TOTAL_COL_WIDTH} font-mono`}>{player.skins}</td>
             {showTotals && (
               <>
-                <td className={`border border-gray-300 px-3 py-2 text-center font-bold bg-blue-100 ${TOTAL_COL_WIDTH}`}>{player.totalScore}</td>
-                <td className={`border border-gray-300 px-3 py-2 text-center font-bold bg-purple-100 ${TOTAL_COL_WIDTH}`}>{(() => {const t = calculateTotalToPar(player); if (t === 0) return 'E'; return t > 0 ? `+${t}` : `${t}`;})()}</td>
+                <td className={`border border-gray-300 px-3 py-2 text-center font-bold bg-blue-100 ${TOTAL_COL_WIDTH} font-mono`}>{player.totalScore}</td>
+                <td className={`border border-gray-300 px-3 py-2 text-center font-bold bg-purple-100 ${TOTAL_COL_WIDTH} font-mono`}>{(() => {const t = calculateTotalToPar(player); if (t === 0) return 'E'; return t > 0 ? `+${t}` : `${t}`;})()}</td>
               </>
             )}
           </tr>
@@ -995,7 +995,7 @@ const renderDesktopTable = (
   );
 
   return (
-    <div className="golf-card">
+    <div className="golf-card fade-in">
       <div className="flex items-center justify-between mb-4">
         <h3 className="text-xl font-bold text-gray-800">Score Card</h3>
         <button
@@ -1023,10 +1023,10 @@ const renderDesktopTable = (
         </div>
       {/* Mobile Table */}
       <div className="md:hidden overflow-x-auto mt-4">
-        <table className="w-full table-fixed border-collapse text-sm">
+        <table className="w-full table-fixed border-collapse divide-y divide-gray-200 text-sm">
           <thead>
             <tr className="bg-gray-100">
-              <th className={`border border-gray-300 px-3 py-2 text-left font-semibold ${HOLE_COL_WIDTH}`}>Hole</th>
+              <th className={`border border-gray-300 px-3 py-2 text-left font-semibold font-mono ${HOLE_COL_WIDTH}`}>Hole</th>
               {game.players.map((player) => (
                 <th
                   key={player.id}
@@ -1063,11 +1063,11 @@ const renderDesktopTable = (
           </thead>
           <tbody>
             <tr className="bg-yellow-50">
-              <td className={`border border-gray-300 px-3 py-2 font-medium ${HOLE_COL_WIDTH}`}>Skins</td>
+              <td className={`border border-gray-300 px-3 py-2 font-medium font-mono ${HOLE_COL_WIDTH}`}>Skins</td>
               {game.players.map((p) => (
                 <td
                   key={p.id}
-                  className={`border border-gray-300 ${mobilePlayerPaddingClass} md:px-2 py-1 text-center font-bold bg-green-100 ${PLAYER_COL_WIDTH} ${mobilePlayerWidthClass}`}
+                  className={`border border-gray-300 ${mobilePlayerPaddingClass} md:px-2 py-1 text-center font-bold bg-green-100 ${PLAYER_COL_WIDTH} ${mobilePlayerWidthClass} font-mono`}
                 >
                   {p.skins}
                 </td>
@@ -1337,11 +1337,11 @@ const renderDesktopTable = (
             {showTotals && (
               <>
                 <tr className="bg-yellow-50">
-                  <td className={`border border-gray-300 px-3 py-2 font-medium ${HOLE_COL_WIDTH}`}>Total</td>
+                  <td className={`border border-gray-300 px-3 py-2 font-medium font-mono ${HOLE_COL_WIDTH}`}>Total</td>
                   {game.players.map((p) => (
                     <td
                       key={p.id}
-                      className={`border border-gray-300 ${mobilePlayerPaddingClass} md:px-2 py-1 text-center font-bold bg-blue-100 ${PLAYER_COL_WIDTH} ${mobilePlayerWidthClass}`}
+                      className={`border border-gray-300 ${mobilePlayerPaddingClass} md:px-2 py-1 text-center font-bold bg-blue-100 ${PLAYER_COL_WIDTH} ${mobilePlayerWidthClass} font-mono`}
                     >
                       {p.totalScore}
                     </td>
@@ -1349,11 +1349,11 @@ const renderDesktopTable = (
                   <td className="border border-gray-300 px-3 py-2" colSpan={4}></td>
                 </tr>
                 <tr className="bg-yellow-50">
-                  <td className={`border border-gray-300 px-3 py-2 font-medium ${HOLE_COL_WIDTH}`}>To Par</td>
+                  <td className={`border border-gray-300 px-3 py-2 font-medium font-mono ${HOLE_COL_WIDTH}`}>To Par</td>
                   {game.players.map((p) => (
                     <td
                       key={p.id}
-                      className={`border border-gray-300 ${mobilePlayerPaddingClass} md:px-2 py-1 text-center font-bold bg-purple-100 ${PLAYER_COL_WIDTH} ${mobilePlayerWidthClass}`}
+                      className={`border border-gray-300 ${mobilePlayerPaddingClass} md:px-2 py-1 text-center font-bold bg-purple-100 ${PLAYER_COL_WIDTH} ${mobilePlayerWidthClass} font-mono`}
                     >
                       {(() => {
                         const toPar = calculateTotalToPar(p);

--- a/src/index.css
+++ b/src/index.css
@@ -32,10 +32,27 @@ code {
   }
 
   .score-input {
-    @apply w-11/12 aspect-square mx-auto text-center rounded-md bg-gray-100 border border-gray-300 focus:bg-white focus:outline-none focus:ring-2 focus:ring-golf-green;
+    @apply w-11/12 aspect-square mx-auto text-center rounded-md bg-gray-100 border border-gray-300 focus:bg-white focus:outline-none focus:ring-2 focus:ring-golf-green font-mono transition-shadow duration-150;
   }
 
   .score-button {
-    @apply w-11/12 aspect-square mx-auto flex items-center justify-center rounded-md cursor-pointer transition-colors;
+    @apply w-11/12 aspect-square mx-auto flex items-center justify-center rounded-md cursor-pointer transition-all duration-150 font-mono transform hover:scale-105 active:scale-95;
+  }
+}
+
+@layer utilities {
+  @keyframes fade-in {
+    from {
+      opacity: 0;
+      transform: translateY(4px);
+    }
+    to {
+      opacity: 1;
+      transform: translateY(0);
+    }
+  }
+
+  .fade-in {
+    animation: fade-in 0.5s ease-in-out both;
   }
 }


### PR DESCRIPTION
## Summary
- polish the scorecard layout and fonts
- add subtle hover animations to score inputs and player icons
- introduce reusable `fade-in` animation
- apply fade-in effects to main views

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865e19471d483259967ca9996688a4b