### PR TITLE
Apply earthy, rugged styling

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -609,11 +609,11 @@ function App() {
   };
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-green-400 to-blue-500 fade-in">
+    <div className="min-h-screen bg-earth-beige fade-in">
       <div className="container mx-auto px-4 py-8">
         <header className="text-center mb-8">
-          <h1 className="text-4xl font-bold text-white mb-2 font-marker">🏌️ The Tour</h1>
-          <p className="text-white/80">Track your game with style</p>
+          <h1 className="text-4xl font-bold text-earth-brown mb-2 font-marker">🏌️ The Tour</h1>
+          <p className="text-earth-brown/80">Track your game with style</p>
         </header>
 
         {showSetup ? (
@@ -621,10 +621,10 @@ function App() {
         ) : game ? (
           <div className="space-y-6">
             <div className="flex justify-between items-center">
-              <div className="text-white">
+              <div className="text-earth-brown">
                 <h2 className="text-2xl font-semibold">{game.course.name}</h2>
-                <p className="text-white/80">{game.course.location} • {game.date}</p>
-                <p className="text-white/80">Par {game.course.totalPar}
+                <p className="text-earth-brown/80">{game.course.location} • {game.date}</p>
+                <p className="text-earth-brown/80">Par {game.course.totalPar}
                   {game.course.totalDistance && ` • ${game.course.totalDistance} yards`}
                 </p>
               </div>

--- a/src/index.css
+++ b/src/index.css
@@ -10,7 +10,13 @@ body {
     sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+  background-color: #f5f5dc;
+  background-image:
+    radial-gradient(rgba(0, 0, 0, 0.05) 1px, transparent 1px),
+    radial-gradient(rgba(0, 0, 0, 0.04) 1px, transparent 1px);
+  background-position: 0 0, 3px 3px;
+  background-size: 6px 6px;
+  background-blend-mode: multiply;
   min-height: 100vh;
 }
 
@@ -29,19 +35,20 @@ code {
 
 @layer components {
   .golf-card {
-    @apply bg-white rounded-lg shadow-lg p-6 border border-gray-200;
+    @apply bg-earth-beige rounded-md shadow-md p-6 border-2 border-dashed border-earth-brown;
   }
   
   .golf-button {
-    @apply bg-golf-green hover:bg-green-800 text-white font-bold py-2 px-4 rounded transition-colors duration-200;
+    @apply bg-earth-green hover:bg-rough text-white font-bold py-2 px-4 rounded border-2 border-earth-brown uppercase tracking-wide transition-colors duration-200;
+    transform: rotate(-1deg);
   }
   
   .golf-input {
-    @apply border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-golf-green focus:border-transparent;
+    @apply border-2 border-dashed border-earth-brown rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-earth-green focus:border-transparent shadow-sm;
   }
 
   .score-input {
-    @apply w-11/12 aspect-square mx-auto text-center rounded-md bg-gray-100 border border-gray-300 focus:bg-white focus:outline-none focus:ring-2 focus:ring-golf-green font-mono transition-shadow duration-150;
+    @apply w-11/12 aspect-square mx-auto text-center rounded-md bg-earth-beige border-2 border-dashed border-earth-brown focus:bg-white focus:outline-none focus:ring-2 focus:ring-earth-green font-mono transition-shadow duration-150;
   }
 
   .score-button {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -10,6 +10,10 @@ module.exports = {
         'fairway': '#8fbc8f',
         'rough': '#556b2f',
         'sand': '#f4d03f',
+        'earth-green': '#556b2f',
+        'earth-burlap': '#deb887',
+        'earth-beige': '#f5f5dc',
+        'earth-brown': '#8b4513',
       },
       fontFamily: {
         marker: ['"Permanent Marker"', 'cursive'],


### PR DESCRIPTION
## Summary
- style: use earth-toned palette in Tailwind config
- style: give body a paper-like texture
- style: roughen card, button, and input visuals
- style: update header colors to match new palette

## Testing
- `npm test --silent --no-watch` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865e549fc708325a0d89e2ccb242e91