### PR TITLE
Persist game state in local storage

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,8 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { Game, Player, Course, CourseHole } from './types/golf';
 import PlayerSetup from './features/player/PlayerSetup';
 import ScoreCard from './features/score/ScoreCard';
+import { loadGame, saveGame, clearGame } from './services/gameService';
 import './App.css';
 
 const calculateSkins = (
@@ -218,8 +219,15 @@ const getFourHoles = (holes: CourseHole[]): number[] => {
 };
 
 function App() {
-  const [game, setGame] = useState<Game | null>(null);
-  const [showSetup, setShowSetup] = useState(true);
+  const initialGame = loadGame();
+  const [game, setGame] = useState<Game | null>(initialGame);
+  const [showSetup, setShowSetup] = useState(!initialGame);
+
+  useEffect(() => {
+    if (game) {
+      saveGame(game);
+    }
+  }, [game]);
   const startNewGame = (players: Player[], course: Course) => {
     const newGame: Game = {
       id: Date.now().toString(),
@@ -604,6 +612,7 @@ function App() {
   };
 
   const resetGame = () => {
+    clearGame();
     setGame(null);
     setShowSetup(true);
   };

--- a/src/services/gameService.ts
+++ b/src/services/gameService.ts
@@ -1,0 +1,31 @@
+import { Game } from '../types/golf';
+
+export const GAME_STORAGE_KEY = 'golfer-current-game';
+
+export const loadGame = (): Game | null => {
+  try {
+    const stored = localStorage.getItem(GAME_STORAGE_KEY);
+    if (stored) {
+      return JSON.parse(stored) as Game;
+    }
+  } catch (err) {
+    console.error('Failed to load saved game', err);
+  }
+  return null;
+};
+
+export const saveGame = (game: Game): void => {
+  try {
+    localStorage.setItem(GAME_STORAGE_KEY, JSON.stringify(game));
+  } catch (err) {
+    console.error('Failed to save game', err);
+  }
+};
+
+export const clearGame = (): void => {
+  try {
+    localStorage.removeItem(GAME_STORAGE_KEY);
+  } catch (err) {
+    console.error('Failed to clear saved game', err);
+  }
+};


### PR DESCRIPTION
## Summary
- add `gameService` for saving and loading current game from `localStorage`
- load any saved game on startup and automatically persist changes
- clear saved state when starting a new game
- fix ESLint import order in game service

## Testing
- `npm run lint` *(fails: react-scripts not found)*
- `npm run test` *(fails: react-scripts not found)*
- `npx tsc --noEmit` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6865ed39425083258f9b2995ed7267f0