### PR TITLE
Simplify setup buttons, make header clickable, prompt to save unsaved scorecard

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -534,6 +534,31 @@ function App() {
     setScorecardTitle('');
   };
 
+  const hasUnsavedScorecard = () => {
+    if (!game) return false;
+    const currentName = scorecardTitle.trim() || game.eventName || 'Untitled Scorecard';
+    if (!activeScorecardId) return true;
+    const saved = savedScorecards.find((item) => item.id === activeScorecardId);
+    if (!saved) return true;
+    return (
+      saved.name !== currentName ||
+      JSON.stringify(saved.data) !== JSON.stringify(game)
+    );
+  };
+
+  const returnToSetup = () => {
+    if (showSetup) return;
+    if (hasUnsavedScorecard()) {
+      const shouldSave = window.confirm(
+        'Save the current scorecard before returning to setup?',
+      );
+      if (shouldSave) {
+        handleSaveScorecard();
+      }
+    }
+    resetGame();
+  };
+
   const formatScorecardLabel = (scorecard: { name: string; data: Game }) => {
     const date = scorecard.data.date;
     const courseName = scorecard.data.course?.name ?? 'Course';
@@ -624,8 +649,13 @@ function App() {
     <div className="min-h-screen fade-in">
       <div className="container mx-auto px-4 py-8">
         <header className="text-center mb-8">
-          <h1 className="text-4xl font-bold text-earth-beige mb-2 font-marker">🏌️ The Tour</h1>
-          <p className="text-earth-beige/80">Track your game with style</p>
+          <button
+            type="button"
+            onClick={returnToSetup}
+            className="text-4xl font-bold text-earth-beige font-marker transition-transform duration-200 hover:scale-105 active:scale-95"
+          >
+            🏌️ The Tour
+          </button>
         </header>
 
         {showSetup ? (
@@ -655,7 +685,7 @@ function App() {
                 >
                   Saved Scorecards
                 </button>
-                <button onClick={resetGame} className="golf-button">
+                <button onClick={returnToSetup} className="golf-button">
                   New Game
                 </button>
               </div>

--- a/src/features/player/PlayerSetup.tsx
+++ b/src/features/player/PlayerSetup.tsx
@@ -205,24 +205,15 @@ const PlayerSetup = ({
       <div className="space-y-6">
         {/* Scorecards */}
         <div className="space-y-3">
-          <div>
-            <label className="block text-sm font-medium text-gray-700 mb-2">
-              Load Saved Scorecard
-            </label>
+          <div className="flex flex-wrap gap-3">
             <button
               onClick={() => setShowScorecardDialog(true)}
               className="px-4 py-2 rounded-md bg-blue-100 text-blue-800 hover:bg-blue-200 transition-colors text-sm"
             >
               Load Saved Scorecard
             </button>
-          </div>
-
-          <div>
-            <label className="block text-sm font-medium text-gray-700 mb-2">
-              Import Scorecards
-            </label>
             <label className="inline-flex items-center px-4 py-2 bg-gray-100 text-gray-800 rounded-md cursor-pointer hover:bg-gray-200 text-sm">
-              Choose JSON file
+              Import Scorecard
               <input
                 type="file"
                 accept="application/json"
@@ -230,10 +221,10 @@ const PlayerSetup = ({
                 className="hidden"
               />
             </label>
-            {importStatus && (
-              <p className="text-xs text-gray-500 mt-2">{importStatus}</p>
-            )}
           </div>
+          {importStatus && (
+            <p className="text-xs text-gray-500">{importStatus}</p>
+          )}
         </div>
 
         {/* Event Details */}


### PR DESCRIPTION
### Motivation
- Simplify the Game Setup UI by removing extra subheaders and combining scorecard actions into two concise buttons.
- Make the app title easier to use as a navigation affordance by making it clickable with a small animation.
- Prevent accidental data loss by prompting the user to save the current scorecard before returning to setup.

### Description
- UI: Consolidated the scorecard actions in `src/features/player/PlayerSetup.tsx` to two side-by-side controls: a `Load Saved Scorecard` button and an `Import Scorecard` button (file input). Removed the previous subheader labels and adjusted where `importStatus` is shown.
- Header: Replaced the static title and tagline in `src/App.tsx` with a clickable `button` version of the `🏌️ The Tour` title (subtle scale animation via Tailwind classes) and removed the `Track your game with style` tagline.
- Navigation / Save prompt: Added `hasUnsavedScorecard()` and `returnToSetup()` in `src/App.tsx`. `returnToSetup()` prompts the user with `window.confirm` to save the current scorecard before returning to setup, calls `handleSaveScorecard()` if confirmed, and then resets to the setup screen. Also updated the `New Game` control to use `returnToSetup()`.
- No API or schema changes; behavior reuses existing `handleSaveScorecard`, `handleImportScorecards` / import handlers, and existing props passed to `PlayerSetup`.

### Testing
- Started the development server with `npm start`; the app compiled successfully (dev server reported "Compiled successfully").
- Captured a UI screenshot via Playwright to verify the updated Game Setup screen (artifact: `artifacts/game-setup.png`).
- No unit/test-suite runs were performed.
- Manual verification: exercised the header click and New Game flow to confirm the save prompt appears (performed during local dev server session).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69457f3178c48325846b684eac639e4c)